### PR TITLE
Fix travis build hang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 - gem install bundler
 - bundle install
 script:
-- travis_wait 60 ./travis/build.sh
+- travis_wait 30 ./travis/build.sh
 branches:
   only:
   - master

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,6 +63,12 @@ platform :ios do
     )
   end
 
+  # https://docs.travis-ci.com/user/common-build-problems/#mac-macos-sierra-1012-code-signing-errors
+  desc "disable prompt asking for password for codesign to access the keychain"
+  lane :noprompt do |options|
+    sh("security set-key-partition-list -S apple-tool:,apple: -k $MATCH_PASSWORD ~/Library/Keychains/ios-build.keychain-db")
+  end
+
   desc "Execute tests"
   lane :test do |options|
     scheme = options[:scheme]

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -26,6 +26,11 @@ Create keychains to store certificates
 fastlane ios certificates
 ```
 Fetches provisioning profile and certificates from github repo
+### ios noprompt
+```
+fastlane ios noprompt
+```
+disable prompt asking for password for codesign to access the keychain
 ### ios test
 ```
 fastlane ios test

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -8,6 +8,7 @@ elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag com
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test scheme:"Psorcast"
     bundle exec fastlane keychains
     bundle exec fastlane certificates
+    bundle exec fastlane noprompt
     # bundle exec fastlane archive scheme:"Psorcast" export_method:"ad-hoc"
     bundle exec fastlane ci_archive scheme:"Psorcast" export_method:"ad-hoc" project:"Psorcast/Psorcast.xcodeproj"
 elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" =~ ^stable-.* ]]; then # non-tag commits to stable branches
@@ -16,6 +17,7 @@ elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" =~ ^stable-.* ]]; then # non-tag co
     bundle exec fastlane bump_all
     bundle exec fastlane keychains
     bundle exec fastlane certificates
+    bundle exec fastlane noprompt
     # bundle exec fastlane archive scheme:"Psorcast" export_method:"ad-hoc"
     bundle exec fastlane ci_archive scheme:"Psorcast" export_method:"ad-hoc" project:"Psorcast/Psorcast.xcodeproj"
 fi


### PR DESCRIPTION
Travis build was hanging due travis moving to MAC OSX Sierra[1]
Fix with "security set-key-partition-list.." command

[1] https://docs.travis-ci.com/user/common-build-problems/#mac-macos-sierra-1012-code-signing-errors