### PR TITLE
PSR-70

### DIFF
--- a/Psorcast/PsorcastValidationTests/JointPainImageViewTests.swift
+++ b/Psorcast/PsorcastValidationTests/JointPainImageViewTests.swift
@@ -172,16 +172,16 @@ class JointPainImageViewTests: XCTestCase {
         var height = CGFloat(40)
         
         var circleCount = 1
-        var background = vc.buttonBackgroundRect(circleIdx: 0, circleCount: circleCount, width: width, height: height)
+        var background = vc.buttonBackgroundRect(circleIdx: 0, circleCount: circleCount, width: width, height: height, alpha: 1.0)
         XCTAssertEqual(background.alpha, CGFloat(1.0))
         XCTAssertEqual(background.rect, CGRect(x: CGFloat(0), y: CGFloat(0), width: width, height: height))
         
         circleCount = 2
-        background = vc.buttonBackgroundRect(circleIdx: 0, circleCount: circleCount, width: width, height: height)
+        background = vc.buttonBackgroundRect(circleIdx: 0, circleCount: circleCount, width: width, height: height, alpha: 1.0)
         XCTAssertEqual(background.alpha, CGFloat(0.5))
         XCTAssertEqual(background.rect, CGRect(x: CGFloat(0), y: CGFloat(0), width: width, height: height))
         
-        background = vc.buttonBackgroundRect(circleIdx: 1, circleCount: circleCount, width: width, height: height)
+        background = vc.buttonBackgroundRect(circleIdx: 1, circleCount: circleCount, width: width, height: height, alpha: 1.0)
         XCTAssertEqual(background.alpha, CGFloat(1.0))
         XCTAssertEqual(background.rect, CGRect(x: CGFloat(10), y: CGFloat(10), width: CGFloat(20), height: CGFloat(20)))
         
@@ -189,16 +189,20 @@ class JointPainImageViewTests: XCTestCase {
         width = CGFloat(66)
         height = CGFloat(66)
         circleCount = 3
-        background = vc.buttonBackgroundRect(circleIdx: 0, circleCount: circleCount, width: width, height: height)
+        background = vc.buttonBackgroundRect(circleIdx: 0, circleCount: circleCount, width: width, height: height, alpha: 1.0)
         XCTAssertEqual(background.alpha, CGFloat(1.0/3.0))
         XCTAssertEqual(background.rect, CGRect(x: CGFloat(0), y: CGFloat(0), width: width, height: height))
         
-        background = vc.buttonBackgroundRect(circleIdx: 1, circleCount: circleCount, width: width, height: height)
+        background = vc.buttonBackgroundRect(circleIdx: 1, circleCount: circleCount, width: width, height: height, alpha: 1.0)
         XCTAssertEqual(background.alpha, CGFloat(2.0/3.0))
         XCTAssertEqual(background.rect, CGRect(x: CGFloat(11), y: CGFloat(11), width: CGFloat(44), height: CGFloat(44)))
         
-        background = vc.buttonBackgroundRect(circleIdx: 2, circleCount: circleCount, width: width, height: height)
+        background = vc.buttonBackgroundRect(circleIdx: 2, circleCount: circleCount, width: width, height: height, alpha: 1.0)
         XCTAssertEqual(background.alpha, CGFloat(1.0))
+        XCTAssertEqual(background.rect, CGRect(x: CGFloat(22), y: CGFloat(22), width: CGFloat(22), height: CGFloat(22)))
+        
+        background = vc.buttonBackgroundRect(circleIdx: 2, circleCount: circleCount, width: width, height: height, alpha: 0.5)
+        XCTAssertEqual(background.alpha, CGFloat(0.5))
         XCTAssertEqual(background.rect, CGRect(x: CGFloat(22), y: CGFloat(22), width: CGFloat(22), height: CGFloat(22)))
     }
 }


### PR DESCRIPTION
Fixed black highlight bug.
When the button is a "system" button, it has some default functionality that is showing the black rectangle.  By making the button "custom" and specifically setting the highlight color, we remove the black rectangle artifact.

Unit tests have been updated to support highlighted button state alpha