### PR TITLE
PSR-186

### DIFF
--- a/Psorcast/PsorcastValidation/DigitalJarOpenCompletionStepViewController.swift
+++ b/Psorcast/PsorcastValidation/DigitalJarOpenCompletionStepViewController.swift
@@ -149,10 +149,12 @@ open class DigitalJarOpenCompletionStepViewController: RSDStepViewController, UI
         // Add the image result of the header
         var url: URL?
         do {
-            if let imageData = image.pngData(),
+            if let pngDataUnwrapped = image.pngData(),
+                let appDelegate = (AppDelegate.shared as? AppDelegate),
+                let jpegData = appDelegate.imageDefaults.convertToJpegData(pngData: pngDataUnwrapped),
                 let outputDir = self.stepViewModel.parentTaskPath?.outputDirectory {
-                url = try RSDFileResultUtility.createFileURL(identifier: self.summaryResultIdentifier, ext: "png", outputDirectory: outputDir, shouldDeletePrevious: true)
-                self.save(imageData, to: url!)
+                url = try RSDFileResultUtility.createFileURL(identifier: self.summaryResultIdentifier, ext: "jpg", outputDirectory: outputDir, shouldDeletePrevious: true)
+                self.save(jpegData, to: url!)
             }
         } catch let error {
             debugPrint("Failed to save the camera image: \(error)")

--- a/Psorcast/PsorcastValidation/FootImaging.json
+++ b/Psorcast/PsorcastValidation/FootImaging.json
@@ -79,7 +79,7 @@
         {
             "identifier"    : "leftFoot",
             "type"          : "imageCapture",
-            "title"         : "Left Toes",
+            "title"         : "Fit in the lines if you can",
             "image": {
                 "type":"fetchable",
                 "imageName": "CameraOverlayLeftFoot",
@@ -123,7 +123,7 @@
         {
             "identifier"    : "rightFoot",
             "type"          : "imageCapture",
-            "title"         : "Right Toes",
+            "title"         : "Fit in the lines if you can",
             "image": {
                 "type":"fetchable",
                 "imageName": "CameraOverlayRightFoot",

--- a/Psorcast/PsorcastValidation/ImageCaptureCompletionStepViewController.swift
+++ b/Psorcast/PsorcastValidation/ImageCaptureCompletionStepViewController.swift
@@ -155,10 +155,12 @@ open class ImageCaptureCompletionStepViewController: RSDInstructionStepViewContr
         // Add the image result of the header
         var url: URL?
         do {
-            if let imageData = image.pngData(),
+            if let pngDataUnwrapped = image.pngData(),
+                let appDelegate = (AppDelegate.shared as? AppDelegate),
+                let jpegData = appDelegate.imageDefaults.convertToJpegData(pngData: pngDataUnwrapped),
                 let outputDir = self.stepViewModel.parentTaskPath?.outputDirectory {
-                url = try RSDFileResultUtility.createFileURL(identifier: self.summaryImageResultIdentifier, ext: "png", outputDirectory: outputDir, shouldDeletePrevious: true)
-                self.save(imageData, to: url!)
+                url = try RSDFileResultUtility.createFileURL(identifier: self.summaryImageResultIdentifier, ext: "jpg", outputDirectory: outputDir, shouldDeletePrevious: true)
+                self.save(jpegData, to: url!)
             }
         } catch let error {
             debugPrint("Failed to save the camera image: \(error)")

--- a/Psorcast/PsorcastValidation/ImageCaptureStepViewController.swift
+++ b/Psorcast/PsorcastValidation/ImageCaptureStepViewController.swift
@@ -581,16 +581,17 @@ open class ImageCaptureStepViewController: RSDStepViewController, UIImagePickerC
     }
     
     func saveCapturedPhotoAndGoForward(pngData: Data?) {
-        guard let imageData = pngData else {
+        guard let pngDataUnwrapped = pngData else {
             return
         }
         
         var url: URL?
         do {
-            if let imageData = pngData,
+            if let appDelegate = (AppDelegate.shared as? AppDelegate),
+                let jpegData = appDelegate.imageDefaults.convertToJpegData(pngData: pngDataUnwrapped),
                 let outputDir = self.stepViewModel.parentTaskPath?.outputDirectory {
-                url = try RSDFileResultUtility.createFileURL(identifier: self.step.identifier, ext: "png", outputDirectory: outputDir, shouldDeletePrevious: true)
-                save(imageData, to: url!)
+                url = try RSDFileResultUtility.createFileURL(identifier: self.step.identifier, ext: "jpg", outputDirectory: outputDir, shouldDeletePrevious: true)
+                self.save(jpegData, to: url!)
             }
         } catch let error {
             debugPrint("Failed to save the camera image: \(error)")

--- a/Psorcast/PsorcastValidation/ImageDefaults.swift
+++ b/Psorcast/PsorcastValidation/ImageDefaults.swift
@@ -15,6 +15,15 @@ class ImageDefaults {
     private let filterProcessingQueue = DispatchQueue(label: "org.sagebase.ResearchSuite.image.filter")
     
     private let filterSuffixKey = "EdgeDetection"
+    
+    /// The compression quality that all raw png images will be compressed to,
+    /// when app uploads to Synapse as JPEG images.
+    public let jpegCompressionQuality = CGFloat(0.5)
+    
+    /// Converts PNG data to scaled JPEG data for smaller file size.
+    public func convertToJpegData(pngData: Data) -> Data? {
+        return (UIImage(data: pngData)?.jpegData(compressionQuality: jpegCompressionQuality))
+    }
 
     /// Saves both the raw image and the sobel edge detection result
     func filterImageAndSave(with identifier: String, pngData: Data) {

--- a/Psorcast/PsorcastValidation/JointPainCompletionStepViewController.swift
+++ b/Psorcast/PsorcastValidation/JointPainCompletionStepViewController.swift
@@ -290,10 +290,12 @@ open class JointPainCompletionStepViewController: RSDStepViewController, JointPa
         let image = PSRImageHelper.convertToImage(self.jointImageView)
         var url: URL?
         do {
-            if let imageData = image.pngData(),
+            if let pngDataUnwrapped = image.pngData(),
+                let appDelegate = (AppDelegate.shared as? AppDelegate),
+                let jpegData = appDelegate.imageDefaults.convertToJpegData(pngData: pngDataUnwrapped),
                 let outputDir = self.stepViewModel.parentTaskPath?.outputDirectory {
-                url = try RSDFileResultUtility.createFileURL(identifier: self.summaryImageResultIdentifier, ext: "png", outputDirectory: outputDir, shouldDeletePrevious: true)
-                self.save(imageData, to: url!)
+                url = try RSDFileResultUtility.createFileURL(identifier: self.summaryImageResultIdentifier, ext: "jpg", outputDirectory: outputDir, shouldDeletePrevious: true)
+                self.save(jpegData, to: url!)
             }
         } catch let error {
             debugPrint("Failed to save the camera image: \(error)")

--- a/Psorcast/PsorcastValidation/PsoriasisDrawCompletionStepViewController.swift
+++ b/Psorcast/PsorcastValidation/PsoriasisDrawCompletionStepViewController.swift
@@ -276,11 +276,13 @@ open class PsoriasisDrawCompletionStepViewController: RSDStepViewController, Pro
     override open func goForward() {
         if let image = self.bodySummaryImageView.image {
             var url: URL?
-            do {
-                if let imageData = image.pngData(),
+            do { 
+                if let pngDataUnwrapped = image.pngData(),
+                    let appDelegate = (AppDelegate.shared as? AppDelegate),
+                    let jpegData = appDelegate.imageDefaults.convertToJpegData(pngData: pngDataUnwrapped),
                     let outputDir = self.stepViewModel.parentTaskPath?.outputDirectory {
-                    url = try RSDFileResultUtility.createFileURL(identifier: summaryImageResultIdentifier, ext: "png", outputDirectory: outputDir)
-                    save(imageData, to: url!)
+                    url = try RSDFileResultUtility.createFileURL(identifier: summaryImageResultIdentifier, ext: "jpg", outputDirectory: outputDir)
+                    save(jpegData, to: url!)
                 }
             } catch let error {
                 debugPrint("Failed to save the image: \(error)")

--- a/Psorcast/PsorcastValidation/PsoriasisDrawStepViewController.swift
+++ b/Psorcast/PsorcastValidation/PsoriasisDrawStepViewController.swift
@@ -251,10 +251,12 @@ open class PsoriasisDrawStepViewController: RSDStepViewController, ProcessorFini
 
             var url: URL?
             do {
-               if let imageData = image.pngData(),
+               if let pngDataUnwrapped = image.pngData(),
+                    let appDelegate = (AppDelegate.shared as? AppDelegate),
+                    let jpegData = appDelegate.imageDefaults.convertToJpegData(pngData: pngDataUnwrapped),
                    let outputDir = self.stepViewModel.parentTaskPath?.outputDirectory {
-                   url = try RSDFileResultUtility.createFileURL(identifier: self.step.identifier, ext: "png", outputDirectory: outputDir, shouldDeletePrevious: true)
-                   self.save(imageData, to: url!)
+                   url = try RSDFileResultUtility.createFileURL(identifier: self.step.identifier, ext: "jpg", outputDirectory: outputDir, shouldDeletePrevious: true)
+                   self.save(jpegData, to: url!)
                }
             } catch let error {
                debugPrint("Failed to save the image: \(error)")


### PR DESCRIPTION
Converted all instances of PNG data to compressed JPEG at 50%.  All synapse uploads are working again.

On my iPhone 6, the image sizes were:

psoriasisAreaPhoto.jpg = 54kb

LeftHand.jpg = 385kb
RightHand.jpg = 335kb
summaryImage.jpg = 719 kb

LeftFoot.jpg = 264kb
RightFoot.jpg =398 kb
summaryImage.jpg = 661 kb

All psoriasis draw jpeg images = 14kb
summaryImage.jpg = 204kb

Digital jar open summary.jpg = 41kb

Joint Counting/Swelling summaryImage.jpg = 7kb

