### PR TITLE
PSR 208

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -1519,8 +1519,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Psorcast/Psorcast.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = KA9Z8R6M6K;
 				INFOPLIST_FILE = Psorcast/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1529,7 +1529,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.sagebionetworks.Psorcast;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development org.sagebionetworks.Psorcast";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Psorcast/Psorcast-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1541,8 +1541,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Psorcast/Psorcast.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = KA9Z8R6M6K;
 				INFOPLIST_FILE = Psorcast/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1551,7 +1551,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.sagebionetworks.Psorcast;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Distribution org.sagebionetworks.Psorcast";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Psorcast/Psorcast-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -1564,8 +1564,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = PsorcastValidation/PsorcastValidation.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = KA9Z8R6M6K;
 				INFOPLIST_FILE = PsorcastValidation/Info.plist;
@@ -1573,9 +1573,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_SWIFT_FLAGS = "-D VALIDATION";
 				PRODUCT_BUNDLE_IDENTIFIER = org.sageBionetworks.psorcastValidation0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development org.sageBionetworks.psorcastValidation0";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "PsorcastValidation/PsorcastValidation-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -1598,6 +1599,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				OTHER_SWIFT_FLAGS = "-D VALIDATION";
 				PRODUCT_BUNDLE_IDENTIFIER = org.sageBionetworks.psorcastValidation0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Distribution org.sageBionetworks.psorcastValidation0";

--- a/Psorcast/PsorcastValidation/HandImaging.json
+++ b/Psorcast/PsorcastValidation/HandImaging.json
@@ -75,7 +75,7 @@
         {
             "identifier"    : "leftHand",
             "type"          : "imageCapture",
-            "title"         : "Fit in the lines if you can",
+            "title"         : "Fit your LEFT hand to the outline if you can",
             "image":{
                 "type":"fetchable",
                 "imageName": "CameraOverlayLeftHand",
@@ -119,7 +119,7 @@
         {
             "identifier"    : "rightHand",
             "type"          : "imageCapture",
-            "title"         : "Fit in the lines if you can",
+            "title"         : "Fit your RIGHT hand to the outline if you can",
             "image":{
                 "type":"fetchable",
                 "imageName": "CameraOverlayRightHand",

--- a/Psorcast/PsorcastValidation/ImageCaptureStepViewController.swift
+++ b/Psorcast/PsorcastValidation/ImageCaptureStepViewController.swift
@@ -258,6 +258,7 @@ open class ImageCaptureStepViewController: RSDStepViewController, UIImagePickerC
         #if VALIDATION
             // validation study will just always show the default overlay
             self.navigationHeader?.imageView?.isHidden = false
+            self.navigationHeader?.imageView?.contentMode = UIView.ContentMode.bottom;
         #else
             // full study should show the custom overlay if available
             if let imageDefaults = (AppDelegate.shared as? AppDelegate)?.imageDefaults,
@@ -269,9 +270,11 @@ open class ImageCaptureStepViewController: RSDStepViewController, UIImagePickerC
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
                     self.navigationHeader?.imageView?.isHidden = false
                     self.navigationHeader?.imageView?.image = lastImage
+                    self.navigationHeader?.imageView?.contentMode = UIView.ContentMode.scaleAspectFit;
                 }
             } else {
                 self.navigationHeader?.imageView?.isHidden = false
+                self.navigationHeader?.imageView?.contentMode = UIView.ContentMode.bottom;
             }
         #endif
     

--- a/Psorcast/PsorcastValidation/ImageCaptureStepViewController.swift
+++ b/Psorcast/PsorcastValidation/ImageCaptureStepViewController.swift
@@ -253,20 +253,28 @@ open class ImageCaptureStepViewController: RSDStepViewController, UIImagePickerC
         self.navigationHeader?.imageView?.isHidden = true
         
         super.setupHeader(header)
-    
-        if let imageDefaults = (AppDelegate.shared as? AppDelegate)?.imageDefaults,
-            let lastImageData = imageDefaults.getSavedFilteredImage(with: self.step.identifier),
-            let lastImage = UIImage(data: lastImageData) {
-            
-            // Setting the navigation header here immediately was not taking effect
-            // Use a delay to go around Research framework
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                self.navigationHeader?.imageView?.isHidden = false
-                self.navigationHeader?.imageView?.image = lastImage
-            }
-        } else {
+        self.navigationHeader?.imageView?.isHidden = false
+        
+        #if VALIDATION
+            // validation study will just always show the default overlay
             self.navigationHeader?.imageView?.isHidden = false
-        }
+        #else
+            // full study should show the custom overlay if available
+            if let imageDefaults = (AppDelegate.shared as? AppDelegate)?.imageDefaults,
+                let lastImageData = imageDefaults.getSavedFilteredImage(with: self.step.identifier),
+                let lastImage = UIImage(data: lastImageData) {
+
+                // Setting the navigation header here immediately was not taking effect
+                // Use a delay to go around Research framework
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    self.navigationHeader?.imageView?.isHidden = false
+                    self.navigationHeader?.imageView?.image = lastImage
+                }
+            } else {
+                self.navigationHeader?.imageView?.isHidden = false
+            }
+        #endif
+    
     }
     
     private var keyValueObservations = [NSKeyValueObservation]()

--- a/Psorcast/PsorcastValidation/ImageCaptureStepViewController.xib
+++ b/Psorcast/PsorcastValidation/ImageCaptureStepViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -32,8 +32,8 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fxA-Tz-ZiS" customClass="RSDNavigationHeaderView" customModule="ResearchUI">
                             <rect key="frame" x="0.0" y="0.0" width="395" height="114"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Walk and Balance" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="d3p-ES-nu8" userLabel="Title Label">
-                                    <rect key="frame" x="24" y="61.999999999999993" width="347" height="28.666666666666664"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Walk and Balance" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="d3p-ES-nu8" userLabel="Title Label">
+                                    <rect key="frame" x="60" y="61.999999999999993" width="275" height="28.666666666666664"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -51,9 +51,9 @@
                             <constraints>
                                 <constraint firstItem="d3p-ES-nu8" firstAttribute="top" secondItem="MAO-q7-fPw" secondAttribute="bottom" constant="-12" id="717-ek-QdP"/>
                                 <constraint firstItem="MAO-q7-fPw" firstAttribute="leading" secondItem="fxA-Tz-ZiS" secondAttribute="leading" constant="24" id="9OQ-QY-59V"/>
-                                <constraint firstAttribute="trailing" secondItem="d3p-ES-nu8" secondAttribute="trailing" constant="24" id="Smt-1Y-XlF"/>
+                                <constraint firstAttribute="trailing" secondItem="d3p-ES-nu8" secondAttribute="trailing" constant="60" id="Smt-1Y-XlF"/>
                                 <constraint firstAttribute="height" constant="114" id="b0u-aS-MUB"/>
-                                <constraint firstItem="d3p-ES-nu8" firstAttribute="leading" secondItem="fxA-Tz-ZiS" secondAttribute="leading" constant="24" id="bQC-or-EVq"/>
+                                <constraint firstItem="d3p-ES-nu8" firstAttribute="leading" secondItem="fxA-Tz-ZiS" secondAttribute="leading" constant="60" id="bQC-or-EVq"/>
                                 <constraint firstItem="MAO-q7-fPw" firstAttribute="top" secondItem="fxA-Tz-ZiS" secondAttribute="top" constant="24" id="c4z-r0-dQU"/>
                             </constraints>
                             <connections>
@@ -136,7 +136,7 @@
     </objects>
     <resources>
         <image name="Camera" width="48" height="48"/>
-        <image name="CameraToggle" width="150" height="150"/>
+        <image name="CameraToggle" width="46" height="40"/>
         <image name="closeActivity" width="50" height="50"/>
     </resources>
 </document>


### PR DESCRIPTION
Update image capture labels text
Tweaked positioning to match Figma better, now two lines instead of 1
Adjusted the overlay image logic so it always shows the default overlay image for the validation target