### PR TITLE
PSR-247

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		CB778674238D18F30009ECF9 /* DigitalJarOpenCompletionStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB778673238D18F30009ECF9 /* DigitalJarOpenCompletionStepViewController.xib */; };
 		CB7CF2422400BF10003E02A5 /* WelcomeVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7CF2412400BF10003E02A5 /* WelcomeVideoViewController.swift */; };
 		CB7CF2482400CFAA003E02A5 /* WelcomeVideo.mov in Resources */ = {isa = PBXBuildFile; fileRef = CB7CF2472400CFAA003E02A5 /* WelcomeVideo.mov */; };
+		CB81C928242D33CD00A84886 /* DataDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81C927242D33CD00A84886 /* DataDefaults.swift */; };
+		CB81C92E242D3AB100A84886 /* MeasureTabViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81C92D242D3AB100A84886 /* MeasureTabViewControllerTests.swift */; };
 		CB85FB52235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85FB51235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift */; };
 		CB85FB56235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85FB55235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift */; };
 		CB8AE6FD233FB53400F5F8AC /* PsoriasisDraw.json in Resources */ = {isa = PBXBuildFile; fileRef = CB8AE6FC233FB53400F5F8AC /* PsoriasisDraw.json */; };
@@ -376,6 +378,8 @@
 		CB778673238D18F30009ECF9 /* DigitalJarOpenCompletionStepViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DigitalJarOpenCompletionStepViewController.xib; sourceTree = "<group>"; };
 		CB7CF2412400BF10003E02A5 /* WelcomeVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeVideoViewController.swift; sourceTree = "<group>"; };
 		CB7CF2472400CFAA003E02A5 /* WelcomeVideo.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = WelcomeVideo.mov; sourceTree = "<group>"; };
+		CB81C927242D33CD00A84886 /* DataDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDefaults.swift; sourceTree = "<group>"; };
+		CB81C92D242D3AB100A84886 /* MeasureTabViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureTabViewControllerTests.swift; sourceTree = "<group>"; };
 		CB85FB51235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PsoriasisDrawTaskResultProcessor.swift; sourceTree = "<group>"; };
 		CB85FB55235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedIdentifiersResultObject.swift; sourceTree = "<group>"; };
 		CB8AE6FC233FB53400F5F8AC /* PsoriasisDraw.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PsoriasisDraw.json; sourceTree = "<group>"; };
@@ -629,6 +633,7 @@
 				CB8F7D512422D73900F77D62 /* StudyTaskFactory.swift */,
 				CBBE0F6524039A5F0072452C /* MeasureTabScheduleManager.swift */,
 				CBE5614E2412BD96009A2930 /* TryItFirstTaskScheduleManager.swift */,
+				CB81C927242D33CD00A84886 /* DataDefaults.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -820,6 +825,7 @@
 				CB67C29323F390AA005B6BCD /* JointPainStepViewControllerTests.swift */,
 				CB67C28E23F390AA005B6BCD /* PSRImageHelperTests.swift */,
 				CB8F7D582423F6BB00F77D62 /* LevenshteinToolsTests.swift */,
+				CB81C92D242D3AB100A84886 /* MeasureTabViewControllerTests.swift */,
 			);
 			path = PsorcastTests;
 			sourceTree = "<group>";
@@ -1175,6 +1181,7 @@
 				CB67C29A23F390AB005B6BCD /* CodableResultObjectTests.swift in Sources */,
 				CB67C29E23F390AB005B6BCD /* CopyStepTests.swift in Sources */,
 				CBC6519423F391BC00C3FF0C /* PsorcastTests.swift in Sources */,
+				CB81C92E242D3AB100A84886 /* MeasureTabViewControllerTests.swift in Sources */,
 				CB67C29723F390AB005B6BCD /* DigitalJarOpenStepViewControllerTests.swift in Sources */,
 				CB67C29D23F390AB005B6BCD /* JointPainStepViewControllerTests.swift in Sources */,
 				CB67C29923F390AB005B6BCD /* JointPainImageViewTests.swift in Sources */,
@@ -1220,6 +1227,7 @@
 				CBDCDCB823F384A400E5CEB8 /* MotorControl+Bridge.swift in Sources */,
 				CBDCDC8C23F3849E00E5CEB8 /* RSDSelectionCollectionViewCell.swift in Sources */,
 				CBDCDCA123F3849E00E5CEB8 /* LearnMoreStepViewController.swift in Sources */,
+				CB81C928242D33CD00A84886 /* DataDefaults.swift in Sources */,
 				CBDD30E82416D403003B0488 /* MeasureTabViewController.swift in Sources */,
 				FFABCBC222DD1EEB00D11109 /* AppDelegate.swift in Sources */,
 				CBDCDC9123F3849E00E5CEB8 /* EndOfValidationStepViewController.swift in Sources */,

--- a/Psorcast/Psorcast/AppDelegate.swift
+++ b/Psorcast/Psorcast/AppDelegate.swift
@@ -54,8 +54,9 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
     /// The task identifier of the try it first intro screens
     let tryItFirstTaskId = "TryItFirstIntro"
     
-    // The app's image data store
+    // The app's image and data store
     public let imageDefaults = ImageDefaults()
+    public let dataDefaults = DataDefaults()
     
     override func instantiateColorPalette() -> RSDColorPalette? {
         return AppDelegate.colorPalette
@@ -187,6 +188,13 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
         // If we finish the onboarding screens, send the user to sign in
         if taskController.task.identifier == "Onboarding" {
             if reason == .completed {
+                
+                // Get the current treatments answer and set it to the data store
+                if let currentTreatmentsResult = taskController.taskViewModel.taskResult.findAnswerResult(with: "treatmentSelection"),
+                    let currentTreatments = currentTreatmentsResult.value as? [String] {
+                    dataDefaults.setCurrentTreatments(treatmentIds: currentTreatments)
+                }                
+                
                 self.showSignInViewController(animated: true)
             } else {
                 self.showWelcomeViewController(animated: true)

--- a/Psorcast/Psorcast/Base.lproj/Main.storyboard
+++ b/Psorcast/Psorcast/Base.lproj/Main.storyboard
@@ -44,14 +44,14 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Oi-Gn-n4p" userLabel="Get started button" customClass="RSDRoundedButton" customModule="ResearchUI">
-                                        <rect key="frame" x="4" y="738.5" width="406" height="52"/>
+                                        <rect key="frame" x="4" y="767.5" width="406" height="30"/>
                                         <state key="normal" title="Get Started"/>
                                         <connections>
                                             <action selector="getStartedTapped" destination="VJ3-hJ-g4d" eventType="touchUpInside" id="5K4-ae-Pkm"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lJG-3B-rEz" userLabel="Login Button" customClass="RSDUnderlinedButton" customModule="ResearchUI">
-                                        <rect key="frame" x="8" y="798.5" width="398" height="33.5"/>
+                                        <rect key="frame" x="8" y="805.5" width="398" height="30"/>
                                         <state key="normal" title="Login">
                                             <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
                                         </state>
@@ -60,7 +60,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fZ4-xJ-Sfz" userLabel="Try it first Button" customClass="RSDUnderlinedButton" customModule="ResearchUI">
-                                        <rect key="frame" x="8" y="838.5" width="398" height="33.5"/>
+                                        <rect key="frame" x="8" y="842" width="398" height="30"/>
                                         <state key="normal" title="Try it first">
                                             <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
                                         </state>
@@ -140,19 +140,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mjc-cg-3zo" userLabel="Header">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="235"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="194"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D8m-la-ykO" userLabel="Top Header">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="148"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="112"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CURRENT TREATMENTS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bHu-d3-yL1">
-                                                <rect key="frame" x="8" y="64" width="398" height="21"/>
+                                                <rect key="frame" x="8" y="48" width="398" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tBT-AP-VDb">
-                                                <rect key="frame" x="48" y="85" width="318" height="30"/>
+                                                <rect key="frame" x="48" y="69" width="318" height="30"/>
                                                 <color key="tintColor" cocoaTouchSystemColor="viewFlipsideBackgroundColor"/>
                                                 <state key="normal" title="Enbrel, Hydrocorizone..."/>
                                             </button>
@@ -160,18 +160,18 @@
                                         <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstItem="tBT-AP-VDb" firstAttribute="leading" secondItem="D8m-la-ykO" secondAttribute="leading" constant="48" id="0Pf-ji-Ekm"/>
-                                            <constraint firstItem="bHu-d3-yL1" firstAttribute="top" secondItem="D8m-la-ykO" secondAttribute="top" constant="64" id="IfX-9w-VSz"/>
+                                            <constraint firstItem="bHu-d3-yL1" firstAttribute="top" secondItem="D8m-la-ykO" secondAttribute="top" constant="48" id="IfX-9w-VSz"/>
                                             <constraint firstItem="tBT-AP-VDb" firstAttribute="top" secondItem="bHu-d3-yL1" secondAttribute="bottom" id="MP2-Zz-1Pu"/>
-                                            <constraint firstAttribute="height" constant="148" id="Mly-lT-RFo"/>
+                                            <constraint firstAttribute="height" constant="112" id="Mly-lT-RFo"/>
                                             <constraint firstAttribute="trailing" secondItem="tBT-AP-VDb" secondAttribute="trailing" constant="48" id="QP7-lY-hCq"/>
                                             <constraint firstItem="bHu-d3-yL1" firstAttribute="leading" secondItem="D8m-la-ykO" secondAttribute="leading" constant="8" id="XpG-kY-KL1"/>
                                             <constraint firstAttribute="trailing" secondItem="bHu-d3-yL1" secondAttribute="trailing" constant="8" id="ZtD-OK-iOe"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EZf-wd-h5e" userLabel="Bottom Header">
-                                        <rect key="frame" x="0.0" y="148" width="414" height="87"/>
+                                        <rect key="frame" x="0.0" y="112" width="414" height="82"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Week 2 Activities" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="K33-1P-nLf">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Treatment Activities" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="K33-1P-nLf">
                                                 <rect key="frame" x="8" y="16" width="398" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
@@ -203,12 +203,12 @@
                                     <constraint firstItem="EZf-wd-h5e" firstAttribute="leading" secondItem="Mjc-cg-3zo" secondAttribute="leading" id="dWT-ik-ZVL"/>
                                     <constraint firstItem="EZf-wd-h5e" firstAttribute="top" secondItem="D8m-la-ykO" secondAttribute="bottom" id="fIU-Hm-I5f"/>
                                     <constraint firstAttribute="trailing" secondItem="EZf-wd-h5e" secondAttribute="trailing" id="kyw-kj-HL7"/>
-                                    <constraint firstAttribute="height" constant="235" id="mfl-1t-9L0"/>
+                                    <constraint firstAttribute="height" constant="194" id="mfl-1t-9L0"/>
                                     <constraint firstAttribute="bottom" secondItem="EZf-wd-h5e" secondAttribute="bottom" id="va3-yG-OaQ"/>
                                 </constraints>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="OR1-ou-7G7">
-                                <rect key="frame" x="0.0" y="251" width="414" height="562"/>
+                                <rect key="frame" x="0.0" y="194" width="414" height="619"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="vi1-YY-mcr">
                                     <size key="itemSize" width="212" height="120"/>
@@ -291,7 +291,7 @@
                         <constraints>
                             <constraint firstItem="w4r-wF-nM3" firstAttribute="trailing" secondItem="Mjc-cg-3zo" secondAttribute="trailing" id="6gT-x6-vXf"/>
                             <constraint firstItem="Mjc-cg-3zo" firstAttribute="leading" secondItem="w4r-wF-nM3" secondAttribute="leading" id="D2F-ct-B7n"/>
-                            <constraint firstItem="OR1-ou-7G7" firstAttribute="top" secondItem="Mjc-cg-3zo" secondAttribute="bottom" constant="16" id="Ova-Bv-kUJ"/>
+                            <constraint firstItem="OR1-ou-7G7" firstAttribute="top" secondItem="Mjc-cg-3zo" secondAttribute="bottom" id="Ova-Bv-kUJ"/>
                             <constraint firstItem="w4r-wF-nM3" firstAttribute="bottom" secondItem="OR1-ou-7G7" secondAttribute="bottom" id="Vpf-4f-48u"/>
                             <constraint firstItem="OR1-ou-7G7" firstAttribute="leading" secondItem="w4r-wF-nM3" secondAttribute="leading" id="hym-aS-Hhh"/>
                             <constraint firstAttribute="top" secondItem="Mjc-cg-3zo" secondAttribute="top" id="lC1-8V-TMS"/>
@@ -376,7 +376,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" contentViewInsetsToSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qql-zN-2Hw">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="812"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="796"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <viewLayoutGuide key="safeArea" id="8bp-7X-8M6"/>
                                 <color key="separatorColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -491,7 +491,7 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Cn-y3-yth">
-                                <rect key="frame" x="0.0" y="812" width="414" height="84"/>
+                                <rect key="frame" x="0.0" y="796" width="414" height="100"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="04Z-nD-hfL" customClass="RSDShadowGradient" customModule="ResearchUI">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="8"/>
@@ -501,7 +501,7 @@
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Fqk-as-DfM" customClass="RSDRoundedButton" customModule="ResearchUI">
-                                        <rect key="frame" x="16" y="16" width="382" height="60"/>
+                                        <rect key="frame" x="24" y="24" width="366" height="60"/>
                                         <state key="normal" title="I’m done trying them out"/>
                                         <connections>
                                             <action selector="signUpForStudyTapped" destination="yhb-JO-pL9" eventType="touchUpInside" id="15x-wS-5M8"/>

--- a/Psorcast/Psorcast/DataDefaults.swift
+++ b/Psorcast/Psorcast/DataDefaults.swift
@@ -1,0 +1,54 @@
+//
+//  DataDefaults.swift
+//  Psorcast
+//
+//  Copyright © 2019 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+
+class DataDefaults {
+    
+    private let currentTreatmentsKey = "CurrentTreatments"
+    private let dateSetCurrentTreatmentsKey = "DateSetCurrentTreatments"
+    
+    
+    public func setCurrentTreatments(treatmentIds: [String]) {
+        UserDefaults.standard.set(treatmentIds, forKey: currentTreatmentsKey)
+        UserDefaults.standard.set(Date(), forKey: dateSetCurrentTreatmentsKey)
+    }
+    
+    public func getCurrentTreatments() -> [String] {
+        return UserDefaults.standard.stringArray(forKey: currentTreatmentsKey) ?? [String]()
+    }
+    
+    public func getDateSetCurrentTreatments() -> Date? {
+        return UserDefaults.standard.object(forKey: dateSetCurrentTreatmentsKey) as? Date
+    }
+}

--- a/Psorcast/PsorcastTests/MeasureTabViewControllerTests.swift
+++ b/Psorcast/PsorcastTests/MeasureTabViewControllerTests.swift
@@ -1,0 +1,165 @@
+//
+// MeasureTabViewControllerTests.swift
+// PsorcastTests
+
+// Copyright © 2019 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import XCTest
+import BridgeApp
+@testable import Psorcast
+
+class MeasureTabViewControllerTests: XCTestCase {
+    
+    let vc = MeasureTabViewController()
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExpiresTime() {
+        let expiresTime = date(5, 0, 0, 0)
+        
+        var now = date(4, 5, 0, 0)
+        XCTAssertEqual(vc.timeUntilExpiration(from: now, until: expiresTime), "19:00:00")
+        
+        now = date(4, 23, 59, 59)
+        XCTAssertEqual(vc.timeUntilExpiration(from: now, until: expiresTime), "00:00:01")
+        
+        now = date(5, 0, 0, 0)
+        XCTAssertEqual(vc.timeUntilExpiration(from: now, until: expiresTime), "00:00:00")
+        
+        now = date(4, 0, 0, 1)
+        XCTAssertEqual(vc.timeUntilExpiration(from: now, until: expiresTime), "23:59:59")
+        
+        now = date(4, 11, 11, 11)
+        XCTAssertEqual(vc.timeUntilExpiration(from: now, until: expiresTime), "12:48:49")
+    }
+    
+    func testActivityWeek() {
+        var weekStr = vc.treatmentWeekLabelText(for: 1)
+        XCTAssertEqual("Treatment Week 1 Activities", weekStr)
+        weekStr = vc.treatmentWeekLabelText(for: 6)
+        XCTAssertEqual("Treatment Week 6 Activities", weekStr)
+        weekStr = vc.treatmentWeekLabelText(for: 11)
+        XCTAssertEqual("Treatment Week 11 Activities", weekStr)
+        weekStr = vc.treatmentWeekLabelText(for: 101)
+        XCTAssertEqual("Treatment Week 101 Activities", weekStr)
+    }
+    
+    func testWeekCalculation() {
+        // Week calculation is based on the start of day for treatment date
+        let now = date(28, 5, 0, 0)
+        
+        var treatmentDate = date(27, 5, 0, 0)
+        var week = vc.weeks(from: treatmentDate, toNow: now)
+        XCTAssertEqual(week, 1)
+        
+        // doesn't matter of the specific time, we use start of day for treatment date
+        treatmentDate = date(21, 5, 0, 1)
+        week = vc.weeks(from: treatmentDate, toNow: now)
+        XCTAssertEqual(week, 2)
+        
+        treatmentDate = date(21, 4, 0, 0)
+        week = vc.weeks(from: treatmentDate, toNow: now)
+        XCTAssertEqual(week, 2)
+        
+        treatmentDate = date(1, 4, 0, 0)
+        week = vc.weeks(from: treatmentDate, toNow: now)
+        XCTAssertEqual(week, 4)
+        
+        // doesn't matter of the specific time, we use start of day for treatment date
+        treatmentDate = date(0, 4, 0, 0)
+        week = vc.weeks(from: treatmentDate, toNow: now)
+        XCTAssertEqual(week, 5)
+    }
+    
+    func testActivityRenewText() {
+        var now = date(27, 5, 0, 0)
+        
+        var treatmentSetDate = date(27, 5, 0, 0)
+        var activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 6 Days")
+                
+        treatmentSetDate = date(26, 5, 0, 0)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 5 Days")
+        
+        treatmentSetDate = date(25, 5, 0, 0)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 4 Days")
+        
+        treatmentSetDate = date(24, 5, 0, 0)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 3 Days")
+        
+        treatmentSetDate = date(23, 5, 0, 0)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 2 Days")
+        
+        treatmentSetDate = date(22, 5, 0, 0)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 1 Day")
+        
+        now = date(27, 5, 0, 0)
+        treatmentSetDate = date(21, 5, 0, 0)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 19:00:00")
+        
+        now = date(27, 23, 59, 59)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 00:00:01")
+        
+        now = date(27, 0, 0, 1)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 23:59:59")
+        
+        now = date(27, 11, 11, 11)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 12:48:49")
+        
+        // This is an edge case where the timer has pass from one week to another
+        // Let's make the count down reach 0, then 
+        now = date(28, 0, 0, 0)
+        activityText = vc.activityRenewalText(from: treatmentSetDate, toNow: now)
+        XCTAssertEqual(activityText, "Activities renew in 00:00:00")
+    }
+    
+    private func date(_ day: Int, _ hour: Int, _ min: Int, _ sec: Int) -> Date {
+        return Calendar.current.date(from: DateComponents(year: 2020, month: 3, day: day, hour: hour, minute: min, second: sec))!
+    }
+}
+

--- a/Psorcast/PsorcastValidation/ImageDefaults.swift
+++ b/Psorcast/PsorcastValidation/ImageDefaults.swift
@@ -2,10 +2,34 @@
 //  ImageDefaults.swift
 //  PsorcastValidation
 //
-//  Created by Michael L DePhillips on 2/8/20.
-//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//  Copyright © 2019 Sage Bionetworks. All rights reserved.
 //
-//  The ImageDefaults class stores images in the user defaults for access later
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
 
 import UIKit
 import GPUImage

--- a/Psorcast/PsorcastValidation/Psorcast.strings
+++ b/Psorcast/PsorcastValidation/Psorcast.strings
@@ -102,3 +102,9 @@
 
 "OTHER_TREATMENT_SECTION_TITLE" = "Other treatments";
 "CURRENT_TREATMENTS_SECTION_TITLE" = "Current treatments";
+
+"TREATMENT_RENEWAL_TITLE_%@" = "Activities renew in %@";
+"TREATMENT_WEEK_TITLE_%@" = "Treatment Week %@ Activities";
+"%@_DAYS_PLURAL" = "%@ Days";
+"%@_DAYS_SINGULAR" = "%@ Day";
+


### PR DESCRIPTION
This PR adds local data storage for the selected current treatments during on boarding.  For this reason, you will have to delete the app and go through on boarding treatment selection for it to work properly.

After you do that, you land on the measure tab.  This screen now has an active timer refreshing the time the activities renew and displays it the user.  The weekly renewal happens at the start of the day (midnight) of the day you selected your current treatments.  

The logic for the time display is similar to PKU, and I brought over some of the code and unit tests from that project.  If the user is more than a day from activities renewing, it will show the number of days, otherwise it gives an HH:MM:SS timer.  See unit tests for all the cases and logic.  Also, see the video in the Jira issue for the transition state from Week 1 -> Week 2 when you are on the screen.