### PR TITLE
PSR-249

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -14,8 +14,10 @@
 		CB09F00323D649FB009D344E /* DigitalJarOpenInstructionStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB09F00223D649FB009D344E /* DigitalJarOpenInstructionStepViewController.swift */; };
 		CB09F0382421D5730005698D /* TreatmentSelectionStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB09F0372421D5730005698D /* TreatmentSelectionStepViewController.swift */; };
 		CB09F03E2421E9E80005698D /* TreatmentSelectionStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB09F03D2421E9E80005698D /* TreatmentSelectionStepViewController.xib */; };
+		CB1535E024395410007D0307 /* ProfileTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1535DF24395410007D0307 /* ProfileTabViewController.swift */; };
 		CB16BF5623E4B9140099FD08 /* GPUImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB16BF5323E4B90B0099FD08 /* GPUImage.framework */; };
 		CB16BF5723E4B9140099FD08 /* GPUImage.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CB16BF5323E4B90B0099FD08 /* GPUImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CB27B9F1243596F4007D36D8 /* MasterScheduleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB27B9F0243596F4007D36D8 /* MasterScheduleManager.swift */; };
 		CB28EBE82396FCA30043D7FE /* JointCounting.mov in Resources */ = {isa = PBXBuildFile; fileRef = CB28EBE52396FCA30043D7FE /* JointCounting.mov */; };
 		CB28EBEA2396FCA30043D7FE /* DigitalJarOpen.mov in Resources */ = {isa = PBXBuildFile; fileRef = CB28EBE72396FCA30043D7FE /* DigitalJarOpen.mov */; };
 		CB422D2A23316EB700787FEE /* BridgeAppUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB422D2923316EB700787FEE /* BridgeAppUI.framework */; };
@@ -57,7 +59,7 @@
 		CB67C29E23F390AB005B6BCD /* CopyStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB67C29423F390AB005B6BCD /* CopyStepTests.swift */; };
 		CB6F54F022E25C5B0073BFE9 /* ParticipantIDRegistrationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6F54EF22E25C5B0073BFE9 /* ParticipantIDRegistrationViewController.swift */; };
 		CB704AC123EF8C4D00CC9D13 /* ImageDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB704AC023EF8C4D00CC9D13 /* ImageDefaults.swift */; };
-		CB72E8AF241C2BC0006ECC24 /* Onboarding.json in Resources */ = {isa = PBXBuildFile; fileRef = CB72E8AA241C2BC0006ECC24 /* Onboarding.json */; };
+		CB72E8AF241C2BC0006ECC24 /* Treatment.json in Resources */ = {isa = PBXBuildFile; fileRef = CB72E8AA241C2BC0006ECC24 /* Treatment.json */; };
 		CB737FEC231B100600FA1D3A /* MDJointSwelling.json in Resources */ = {isa = PBXBuildFile; fileRef = CB737FEB231B100600FA1D3A /* MDJointSwelling.json */; };
 		CB77866C238984790009ECF9 /* DigitalJarOpenStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB77866B238984790009ECF9 /* DigitalJarOpenStepViewController.swift */; };
 		CB778670238B3F4D0009ECF9 /* DigitalJarOpenStepViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB77866F238B3F4D0009ECF9 /* DigitalJarOpenStepViewControllerTests.swift */; };
@@ -65,7 +67,6 @@
 		CB778674238D18F30009ECF9 /* DigitalJarOpenCompletionStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB778673238D18F30009ECF9 /* DigitalJarOpenCompletionStepViewController.xib */; };
 		CB7CF2422400BF10003E02A5 /* WelcomeVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB7CF2412400BF10003E02A5 /* WelcomeVideoViewController.swift */; };
 		CB7CF2482400CFAA003E02A5 /* WelcomeVideo.mov in Resources */ = {isa = PBXBuildFile; fileRef = CB7CF2472400CFAA003E02A5 /* WelcomeVideo.mov */; };
-		CB81C928242D33CD00A84886 /* DataDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81C927242D33CD00A84886 /* DataDefaults.swift */; };
 		CB81C92E242D3AB100A84886 /* MeasureTabViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81C92D242D3AB100A84886 /* MeasureTabViewControllerTests.swift */; };
 		CB85FB52235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85FB51235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift */; };
 		CB85FB56235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85FB55235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift */; };
@@ -98,6 +99,8 @@
 		CBA0250E23FC6B2500604F2D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CBA0250823FC6B2500604F2D /* Main.storyboard */; };
 		CBA8390E234A6B3F00408D81 /* EndOfValidationStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBA8390C234A6B3F00408D81 /* EndOfValidationStepViewController.swift */; };
 		CBA8390F234A6B3F00408D81 /* EndOfValidationStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CBA8390D234A6B3F00408D81 /* EndOfValidationStepViewController.xib */; };
+		CBAF1DA32437C93700ECC699 /* StudyProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAF1DA22437C93700ECC699 /* StudyProfileManager.swift */; };
+		CBAF1DA92437CB2A00ECC699 /* StudyExternalIdRegistrationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBAF1DA82437CB2A00ECC699 /* StudyExternalIdRegistrationViewController.swift */; };
 		CBB90AE82381FF8700F1DFA4 /* PsoriasisAreaPhoto.mov in Resources */ = {isa = PBXBuildFile; fileRef = CBB90AE52381FF8500F1DFA4 /* PsoriasisAreaPhoto.mov */; };
 		CBB90AE92381FF8700F1DFA4 /* FingersPhoto.mov in Resources */ = {isa = PBXBuildFile; fileRef = CBB90AE62381FF8600F1DFA4 /* FingersPhoto.mov */; };
 		CBB90AEA2381FF8700F1DFA4 /* ToesPhoto.mov in Resources */ = {isa = PBXBuildFile; fileRef = CBB90AE72381FF8700F1DFA4 /* ToesPhoto.mov */; };
@@ -106,7 +109,6 @@
 		CBB93CB5234252BC00321A4D /* PsoriasisDrawCompletionStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB93CB4234252BC00321A4D /* PsoriasisDrawCompletionStepViewController.swift */; };
 		CBB93CB7234252D000321A4D /* PsoriasisDrawCompletionStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CBB93CB6234252D000321A4D /* PsoriasisDrawCompletionStepViewController.xib */; };
 		CBBC8771239F028300AC9D8E /* PsoriasisDraw.mov in Resources */ = {isa = PBXBuildFile; fileRef = CBBC8770239F028300AC9D8E /* PsoriasisDraw.mov */; };
-		CBBE0F6624039A5F0072452C /* MeasureTabScheduleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBE0F6524039A5F0072452C /* MeasureTabScheduleManager.swift */; };
 		CBC0C85B242B2E1100E2EE80 /* PsorcastValidationTestsAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CBC0C85A242B2E1100E2EE80 /* PsorcastValidationTestsAssets.xcassets */; };
 		CBC0C85E242BBBF000E2EE80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CBC0C85C242BBBEF00E2EE80 /* Assets.xcassets */; };
 		CBC6519423F391BC00C3FF0C /* PsorcastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC6519323F391BC00C3FF0C /* PsorcastTests.swift */; };
@@ -330,7 +332,9 @@
 		CB09F00223D649FB009D344E /* DigitalJarOpenInstructionStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DigitalJarOpenInstructionStepViewController.swift; sourceTree = "<group>"; };
 		CB09F0372421D5730005698D /* TreatmentSelectionStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreatmentSelectionStepViewController.swift; sourceTree = "<group>"; };
 		CB09F03D2421E9E80005698D /* TreatmentSelectionStepViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TreatmentSelectionStepViewController.xib; sourceTree = "<group>"; };
+		CB1535DF24395410007D0307 /* ProfileTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabViewController.swift; sourceTree = "<group>"; };
 		CB16BF4723E4B90B0099FD08 /* GPUImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = GPUImage.xcodeproj; path = ../gpuimage/GPUImage.xcodeproj; sourceTree = "<group>"; };
+		CB27B9F0243596F4007D36D8 /* MasterScheduleManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterScheduleManager.swift; sourceTree = "<group>"; };
 		CB28EBE52396FCA30043D7FE /* JointCounting.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = JointCounting.mov; sourceTree = "<group>"; };
 		CB28EBE72396FCA30043D7FE /* DigitalJarOpen.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = DigitalJarOpen.mov; sourceTree = "<group>"; };
 		CB422D2923316EB700787FEE /* BridgeAppUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeAppUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -370,7 +374,7 @@
 		CB67C29423F390AB005B6BCD /* CopyStepTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CopyStepTests.swift; sourceTree = "<group>"; };
 		CB6F54EF22E25C5B0073BFE9 /* ParticipantIDRegistrationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParticipantIDRegistrationViewController.swift; sourceTree = "<group>"; };
 		CB704AC023EF8C4D00CC9D13 /* ImageDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDefaults.swift; sourceTree = "<group>"; };
-		CB72E8AA241C2BC0006ECC24 /* Onboarding.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Onboarding.json; sourceTree = "<group>"; };
+		CB72E8AA241C2BC0006ECC24 /* Treatment.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Treatment.json; sourceTree = "<group>"; };
 		CB737FEB231B100600FA1D3A /* MDJointSwelling.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MDJointSwelling.json; sourceTree = "<group>"; };
 		CB77866B238984790009ECF9 /* DigitalJarOpenStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DigitalJarOpenStepViewController.swift; sourceTree = "<group>"; };
 		CB77866F238B3F4D0009ECF9 /* DigitalJarOpenStepViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DigitalJarOpenStepViewControllerTests.swift; sourceTree = "<group>"; };
@@ -378,7 +382,6 @@
 		CB778673238D18F30009ECF9 /* DigitalJarOpenCompletionStepViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = DigitalJarOpenCompletionStepViewController.xib; sourceTree = "<group>"; };
 		CB7CF2412400BF10003E02A5 /* WelcomeVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeVideoViewController.swift; sourceTree = "<group>"; };
 		CB7CF2472400CFAA003E02A5 /* WelcomeVideo.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = WelcomeVideo.mov; sourceTree = "<group>"; };
-		CB81C927242D33CD00A84886 /* DataDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDefaults.swift; sourceTree = "<group>"; };
 		CB81C92D242D3AB100A84886 /* MeasureTabViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureTabViewControllerTests.swift; sourceTree = "<group>"; };
 		CB85FB51235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PsoriasisDrawTaskResultProcessor.swift; sourceTree = "<group>"; };
 		CB85FB55235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedIdentifiersResultObject.swift; sourceTree = "<group>"; };
@@ -406,6 +409,8 @@
 		CBA0250923FC6B2500604F2D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		CBA8390C234A6B3F00408D81 /* EndOfValidationStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EndOfValidationStepViewController.swift; sourceTree = "<group>"; };
 		CBA8390D234A6B3F00408D81 /* EndOfValidationStepViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EndOfValidationStepViewController.xib; sourceTree = "<group>"; };
+		CBAF1DA22437C93700ECC699 /* StudyProfileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyProfileManager.swift; sourceTree = "<group>"; };
+		CBAF1DA82437CB2A00ECC699 /* StudyExternalIdRegistrationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudyExternalIdRegistrationViewController.swift; sourceTree = "<group>"; };
 		CBB90AE52381FF8500F1DFA4 /* PsoriasisAreaPhoto.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = PsoriasisAreaPhoto.mov; sourceTree = "<group>"; };
 		CBB90AE62381FF8600F1DFA4 /* FingersPhoto.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = FingersPhoto.mov; sourceTree = "<group>"; };
 		CBB90AE72381FF8700F1DFA4 /* ToesPhoto.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = ToesPhoto.mov; sourceTree = "<group>"; };
@@ -414,7 +419,6 @@
 		CBB93CB4234252BC00321A4D /* PsoriasisDrawCompletionStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PsoriasisDrawCompletionStepViewController.swift; sourceTree = "<group>"; };
 		CBB93CB6234252D000321A4D /* PsoriasisDrawCompletionStepViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PsoriasisDrawCompletionStepViewController.xib; sourceTree = "<group>"; };
 		CBBC8770239F028300AC9D8E /* PsoriasisDraw.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = PsoriasisDraw.mov; sourceTree = "<group>"; };
-		CBBE0F6524039A5F0072452C /* MeasureTabScheduleManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureTabScheduleManager.swift; sourceTree = "<group>"; };
 		CBC0C85A242B2E1100E2EE80 /* PsorcastValidationTestsAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = PsorcastValidationTestsAssets.xcassets; sourceTree = "<group>"; };
 		CBC0C85C242BBBEF00E2EE80 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CBC0C85D242BBBF000E2EE80 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -563,7 +567,9 @@
 			children = (
 				CBE561542412BD9D009A2930 /* TryItFirstTaskTableViewController.swift */,
 				CB7CF2412400BF10003E02A5 /* WelcomeVideoViewController.swift */,
+				CBAF1DA82437CB2A00ECC699 /* StudyExternalIdRegistrationViewController.swift */,
 				CBDD30E72416D403003B0488 /* MeasureTabViewController.swift */,
+				CB1535DF24395410007D0307 /* ProfileTabViewController.swift */,
 				CB09F03D2421E9E80005698D /* TreatmentSelectionStepViewController.xib */,
 				CB09F0372421D5730005698D /* TreatmentSelectionStepViewController.swift */,
 				CB4794F42426B39900D5A7E6 /* TreatmentSelectionStepObject.swift */,
@@ -631,9 +637,9 @@
 			isa = PBXGroup;
 			children = (
 				CB8F7D512422D73900F77D62 /* StudyTaskFactory.swift */,
-				CBBE0F6524039A5F0072452C /* MeasureTabScheduleManager.swift */,
+				CBAF1DA22437C93700ECC699 /* StudyProfileManager.swift */,
 				CBE5614E2412BD96009A2930 /* TryItFirstTaskScheduleManager.swift */,
-				CB81C927242D33CD00A84886 /* DataDefaults.swift */,
+				CB27B9F0243596F4007D36D8 /* MasterScheduleManager.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -805,7 +811,7 @@
 				CB7CF23C2400BE84003E02A5 /* ViewControllers */,
 				CB4794EB2426B31D00D5A7E6 /* Utils */,
 				CB7CF2432400C627003E02A5 /* Resources */,
-				CB72E8AA241C2BC0006ECC24 /* Onboarding.json */,
+				CB72E8AA241C2BC0006ECC24 /* Treatment.json */,
 				FF50109C22DD20DE0035E83C /* Support Files */,
 			);
 			path = Psorcast;
@@ -1095,7 +1101,7 @@
 				CBDCDC9623F3849E00E5CEB8 /* ImageCaptureStepViewController.xib in Resources */,
 				CB9F5E2422E0BED3003FBCEF /* lato_lightitalic.ttf in Resources */,
 				CBDCDCB423F3849E00E5CEB8 /* DigitalJarOpenCompletionStepViewController.xib in Resources */,
-				CB72E8AF241C2BC0006ECC24 /* Onboarding.json in Resources */,
+				CB72E8AF241C2BC0006ECC24 /* Treatment.json in Resources */,
 				CBDCDC8323F3848E00E5CEB8 /* FingersPhoto.mov in Resources */,
 				CBDD30E62416C7D1003B0488 /* PsorcastAssets.xcassets in Resources */,
 				CBDCDC9423F3849E00E5CEB8 /* ParticipantIDRegistrationViewController.xib in Resources */,
@@ -1218,8 +1224,8 @@
 				CBDCDC8B23F3849E00E5CEB8 /* RSDCollectionViewCell.swift in Sources */,
 				CBDCDCA523F3849E00E5CEB8 /* PsoriasisAreaPhotoResultObject.swift in Sources */,
 				CBDCDCBA23F384A400E5CEB8 /* PsoriasisDrawTaskResultProcessor.swift in Sources */,
-				CBBE0F6624039A5F0072452C /* MeasureTabScheduleManager.swift in Sources */,
 				CBDCDCB323F3849E00E5CEB8 /* DigitalJarOpenCompletionStepViewController.swift in Sources */,
+				CB1535E024395410007D0307 /* ProfileTabViewController.swift in Sources */,
 				CBDCDCA923F3849E00E5CEB8 /* PsoriasisDrawStepViewController.swift in Sources */,
 				CB4794F32426B36C00D5A7E6 /* ViewUtils.swift in Sources */,
 				CBDCDCA323F3849E00E5CEB8 /* PsoriasisAreaPhotoStepViewController.swift in Sources */,
@@ -1227,7 +1233,6 @@
 				CBDCDCB823F384A400E5CEB8 /* MotorControl+Bridge.swift in Sources */,
 				CBDCDC8C23F3849E00E5CEB8 /* RSDSelectionCollectionViewCell.swift in Sources */,
 				CBDCDCA123F3849E00E5CEB8 /* LearnMoreStepViewController.swift in Sources */,
-				CB81C928242D33CD00A84886 /* DataDefaults.swift in Sources */,
 				CBDD30E82416D403003B0488 /* MeasureTabViewController.swift in Sources */,
 				FFABCBC222DD1EEB00D11109 /* AppDelegate.swift in Sources */,
 				CBDCDC9123F3849E00E5CEB8 /* EndOfValidationStepViewController.swift in Sources */,
@@ -1235,8 +1240,11 @@
 				CBDCDC9723F3849E00E5CEB8 /* ImageCaptureCompletionStepViewController.swift in Sources */,
 				CBDCDC9323F3849E00E5CEB8 /* ParticipantIDRegistrationViewController.swift in Sources */,
 				CB09F0382421D5730005698D /* TreatmentSelectionStepViewController.swift in Sources */,
+				CBAF1DA32437C93700ECC699 /* StudyProfileManager.swift in Sources */,
+				CB27B9F1243596F4007D36D8 /* MasterScheduleManager.swift in Sources */,
 				CBDCDC9C23F3849E00E5CEB8 /* JointPainImageView.swift in Sources */,
 				CBDCDC8F23F3849E00E5CEB8 /* ExternalIDRegistrationViewController.swift in Sources */,
+				CBAF1DA92437CB2A00ECC699 /* StudyExternalIdRegistrationViewController.swift in Sources */,
 				CBDCDC9D23F3849E00E5CEB8 /* JointPainStepViewController.swift in Sources */,
 				CB4794F12426B33300D5A7E6 /* LevenshteinTools.swift in Sources */,
 				CB7CF2422400BF10003E02A5 /* WelcomeVideoViewController.swift in Sources */,

--- a/Psorcast/Psorcast/Base.lproj/Main.storyboard
+++ b/Psorcast/Psorcast/Base.lproj/Main.storyboard
@@ -147,6 +147,9 @@
                                                 <rect key="frame" x="48" y="69" width="318" height="30"/>
                                                 <color key="tintColor" cocoaTouchSystemColor="viewFlipsideBackgroundColor"/>
                                                 <state key="normal" title="Enbrel, Hydrocorizone..."/>
+                                                <connections>
+                                                    <action selector="treatmentTapped" destination="ehR-um-ksg" eventType="touchUpInside" id="PEI-WR-rSk"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -425,7 +428,7 @@
                         <segue destination="ehR-um-ksg" kind="relationship" relationship="viewControllers" id="Ifi-Dg-ZaJ"/>
                         <segue destination="0VO-CW-s3X" kind="relationship" relationship="viewControllers" id="9Sg-YJ-ZpD"/>
                         <segue destination="JqJ-Ex-KGH" kind="relationship" relationship="viewControllers" id="4VR-YP-6WD"/>
-                        <segue destination="34b-e6-vS6" kind="relationship" relationship="viewControllers" id="A3N-ft-QvU"/>
+                        <segue destination="Zvf-eK-tGm" kind="relationship" relationship="viewControllers" id="FKF-09-0o5"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aWh-U2-7oE" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -449,20 +452,33 @@
             <point key="canvasLocation" x="1270" y="-642"/>
         </scene>
         <!--Profile-->
-        <scene sceneID="cyx-Bk-1Yt">
+        <scene sceneID="af0-3V-wGp">
             <objects>
-                <viewController id="34b-e6-vS6" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="2zK-jb-m9P">
+                <tableViewController id="Zvf-eK-tGm" customClass="ProfileTabViewController" customModule="Psorcast" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="F2I-9T-GB3">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                        <viewLayoutGuide key="safeArea" id="cX7-3V-Nv0"/>
-                    </view>
-                    <tabBarItem key="tabBarItem" title="Profile" image="ProfileTabIcon" id="I1y-pj-gda"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="KdR-B6-hB0" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="3ff-tM-fhY">
+                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3ff-tM-fhY" id="hTx-kc-ZQQ">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="Zvf-eK-tGm" id="6tZ-N3-RFc"/>
+                            <outlet property="delegate" destination="Zvf-eK-tGm" id="CC7-xq-ftn"/>
+                        </connections>
+                    </tableView>
+                    <tabBarItem key="tabBarItem" title="Profile" image="ProfileTabIcon" id="466-Fv-pfO"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LUN-g2-6lr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2280" y="-959"/>
+            <point key="canvasLocation" x="2262" y="-928"/>
         </scene>
         <!--Try It First Task Table View Controller-->
         <scene sceneID="e1h-b6-pkd">

--- a/Psorcast/Psorcast/MasterScheduleManager.swift
+++ b/Psorcast/Psorcast/MasterScheduleManager.swift
@@ -37,13 +37,16 @@ import Research
 import MotorControl
 
 /// Subclass the schedule manager to set up a predicate to filter the schedules.
-public class MeasureTabScheduleManager : SBAScheduleManager {
+public class MasterScheduleManager : SBAScheduleManager {
+    
+    /// The shared access to the schedule manager
+    public static let shared = MasterScheduleManager()
     
     /// The schedules will be sorted in this order
     public let sortOrder: [RSDIdentifier] = [.psoriasisDrawTask, .psoriasisAreaPhotoTask, .digitalJarOpenTask, .handImagingTask, .footImagingTask, .walkingTask, .jointCountingTask]
     
     /// The schedules will filter to only have these tasks
-    public let filter: [RSDIdentifier] = [.psoriasisDrawTask, .digitalJarOpenTask, .walkingTask, .jointCountingTask]
+    public var filter: [RSDIdentifier] = [.psoriasisDrawTask, .psoriasisAreaPhotoTask, .digitalJarOpenTask, .handImagingTask, .footImagingTask, .walkingTask, .jointCountingTask]
     
     ///
     /// - returns: the count of the sorted schedules

--- a/Psorcast/Psorcast/ProfileTabViewController.swift
+++ b/Psorcast/Psorcast/ProfileTabViewController.swift
@@ -1,0 +1,289 @@
+//
+//  ProfileTabViewController.swift
+//  Psorcast
+//
+//  Copyright © 2019 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import BridgeApp
+import BridgeSDK
+import MotorControl
+
+class ProfileTabViewController: UITableViewController, RSDTaskViewControllerDelegate {
+    
+    /// The profile manager
+    let profileManager = (AppDelegate.shared as? AppDelegate)?.profileManager
+    let profileDataSource = (AppDelegate.shared as? AppDelegate)?.profileDataSource
+    
+    open var design = AppDelegate.designSystem
+    
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.setupTableView()
+    }
+    
+    override open func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.tableView.reloadData()
+        
+        // Reload the schedules and add an observer to observe changes.
+        if let manager = profileManager {
+            NotificationCenter.default.addObserver(forName: .SBAUpdatedReports, object: manager, queue: OperationQueue.main) { (notification) in
+                self.tableView.reloadData()
+            }
+        }
+    }
+
+    func setupTableView() {
+        self.tableView.estimatedSectionHeaderHeight = 40
+        
+        self.tableView.register(ProfileTableHeaderView.self, forHeaderFooterViewReuseIdentifier: ProfileTableHeaderView.className)
+        
+        self.tableView.register(ProfileTableViewCell.self, forCellReuseIdentifier: String(describing: ProfileTableViewCell.self))
+        
+        let header = UIView(frame: CGRect(x: 0, y: 0, width: self.view.bounds.width, height: 100))
+        header.backgroundColor = design.colorRules.backgroundPrimary.color
+        let title = UILabel(frame: CGRect(x: 24, y: 33, width: self.view.bounds.width - 48, height: 33))
+        title.font = self.design.fontRules.font(for: .largeHeader)
+        title.textColor = self.design.colorRules.textColor(on: design.colorRules.backgroundPrimary, for: .largeHeader)
+        title.text = Localization.localizedString("PROFILE_TITLE")
+        header.addSubview(title)
+        self.tableView.tableHeaderView = header
+    }
+    
+    // MARK: - Table view data source
+       
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return self.profileDataSource?.numberOfSections() ?? 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.profileDataSource?.numberOfRows(for: section) ?? 0
+    }
+   
+    func itemForRow(at indexPath: IndexPath) -> SBAProfileTableItem? {
+        return self.profileDataSource?.profileTableItem(at: indexPath)
+    }
+   
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let tableItem = itemForRow(at: indexPath)
+        let titleText = tableItem?.title
+        let detailText = tableItem?.detail
+        let cell = tableView.dequeueReusableCell(withIdentifier: String(describing: ProfileTableViewCell.self), for: indexPath) as! ProfileTableViewCell
+       
+        // Configure the cell...
+        cell.titleLabel?.text = titleText
+        cell.detailLabel?.text = detailText
+        cell.setDesignSystem(self.design, with: RSDColorTile(RSDColor.white, usesLightStyle: true))
+       
+        return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        guard self.profileDataSource?.title(for: section) != nil else { return CGFloat.leastNormalMagnitude }
+        return UITableView.automaticDimension
+    }
+    
+    override func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return self.tableView.estimatedSectionHeaderHeight
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+    
+    override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return self.tableView.estimatedRowHeight
+    }
+    
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let title = self.profileDataSource?.title(for: section) else { return nil }
+        
+        let sectionHeaderView = tableView.dequeueReusableHeaderFooterView(withIdentifier: ProfileTableHeaderView.className) as! ProfileTableHeaderView
+        sectionHeaderView.titleLabel?.text = title
+        
+        return sectionHeaderView
+    }
+    
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        let footer = UIView(frame: CGRect(x: 0, y: 0, width: self.tableView.bounds.width, height: 8))
+        footer.backgroundColor = self.design.colorRules.backgroundPrimary.color
+        return footer
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        guard let item = itemForRow(at: indexPath),
+                let onSelected = item.onSelected
+            else {
+            return
+        }
+        
+        if let profileItem = item as? SBAProfileItemProfileTableItem,
+            let vc = ProfileTabViewController.createTreatmentProfileVc(profileManager: self.profileManager, for: profileItem.profileItemKey) {
+            vc.delegate = self
+            self.show(vc, sender: self)
+        }
+        
+        // TMight need these as we add more profile items
+//        switch onSelected {
+//            case SBAProfileOnSelectedAction.prof
+//                self.showHealthInformationItem(for: (item as? HealthInformationProfileTableItem)?.profileItemKey)
+//                break
+//            default:
+//                break
+//        }
+    }
+    
+    /// Create the individual treatment profile view controller
+    public static func createTreatmentProfileVc(profileManager: StudyProfileManager?, for profileKey: String?) -> RSDTaskViewController? {
+        guard let key = profileKey else { return nil }
+        
+        let resource = RSDResourceTransformerObject(resourceName: "Treatment.json", bundle: Bundle.main)
+        do {
+            let task = try RSDFactory.shared.decodeTask(with: resource)
+            if let step = task.stepNavigator.step(with: key) {
+                var navigator = RSDConditionalStepNavigatorObject(with: [step])
+                navigator.progressMarkers = []
+                let task = RSDTaskObject(identifier: RSDIdentifier.treatmentTask.rawValue, stepNavigator: navigator)
+                let vc = RSDTaskViewController(task: task)
+                
+                // Set the initial state of the question answer
+                if let prevAnswer = profileManager?.answerResult(for: key) {
+                    vc.taskViewModel.append(previousResult: prevAnswer)
+                }
+                
+                return vc
+            }
+        } catch {
+            NSLog("Failed to create task from Onboarding.json \(error)")
+        }
+        return nil
+    }
+    
+    override func tableView(_ tableView: UITableView, didHighlightRowAt indexPath: IndexPath) {
+        if let cell = tableView.cellForRow(at: indexPath) {
+            let background = RSDColorTile(RSDColor.white, usesLightStyle: true)
+            cell.contentView.backgroundColor = self.design.colorRules.tableCellBackground(on: background, isSelected: true).color
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, didUnhighlightRowAt indexPath: IndexPath) {
+        if let cell = tableView.cellForRow(at: indexPath) {
+            cell.contentView.backgroundColor = RSDColor.white
+        }
+    }
+    
+    // MARK: - Task view controller delegate
+    
+    func taskController(_ taskController: RSDTaskController, didFinishWith reason: RSDTaskFinishReason, error: Error?) {
+        self.profileManager?.taskController(taskController, didFinishWith: reason, error: error)
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    func taskController(_ taskController: RSDTaskController, readyToSave taskViewModel: RSDTaskViewModel) {
+        let prepared = ProfileTabViewController.prepareTreatmentResultForUpload(profileManager: self.profileManager, taskViewModel: taskViewModel)
+        self.profileManager?.taskController(taskController, readyToSave: prepared)
+    }
+    
+    // If we just upload the answer to the individual question,
+    // the report data will be incomplete when we search later
+    // Let's build the full expected treatment task answers each time
+    public static func prepareTreatmentResultForUpload(profileManager: StudyProfileManager?, taskViewModel: RSDTaskViewModel) -> RSDTaskViewModel {
+        if taskViewModel.task?.identifier == RSDIdentifier.treatmentTask.identifierValue {
+            for treatmentStepId in profileManager?.treatmentStepIdentifiers ?? [] {
+                // Don't overwrite any answers from the task
+                if taskViewModel.taskResult.findResult(with: treatmentStepId) == nil,
+                    let current = profileManager?.answerResult(for: treatmentStepId) {
+                    // Append the current state of the rest of the treatments task
+                    taskViewModel.taskResult.appendStepHistory(with: current)
+                }
+            }
+        }
+        return taskViewModel
+    }
+}
+
+class ProfileTableHeaderView: RSDTableSectionHeader {
+    static let className = String(describing: ProfileTableHeaderView.self)
+}
+
+open class ProfileTableViewCell: RSDSelectionTableViewCell {
+    
+    internal let kLeadingMargin: CGFloat = 48.0
+    
+    @IBOutlet public var chevron: UIImageView?
+    
+    override open var isSelected: Bool {
+        didSet {
+            titleLabel?.font = self.designSystem?.fontRules.font(for: .mediumHeader)
+        }
+    }
+    
+    public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        // Add the line separator
+        chevron = UIImageView()
+        chevron?.image = UIImage(named: "RightChevron")
+        chevron!.contentMode = .scaleAspectFit
+        contentView.addSubview(chevron!)
+        
+        chevron!.translatesAutoresizingMaskIntoConstraints = false
+        chevron!.rsd_makeWidth(.equal, 18.0)
+        chevron!.rsd_makeHeight(.equal, 18.0)
+        chevron!.rsd_alignToSuperview([.trailing], padding: 24.0)
+        chevron!.rsd_alignCenterVertical(padding: 0.0)
+        
+        // The title and detail need larger leading margins per design
+        if let oldLeading = titleLabel?.superview?.constraints.first(where: { $0.firstAttribute == .leading && ($0.firstItem as? UILabel) == titleLabel }) {
+            titleLabel?.superview?.removeConstraint(oldLeading)
+            titleLabel?.rsd_alignToSuperview([.leading], padding: kLeadingMargin)
+        }
+        if let oldLeading = detailLabel?.superview?.constraints.first(where: { $0.firstAttribute == .leading && ($0.firstItem as? UILabel) == detailLabel }) {
+            detailLabel?.superview?.removeConstraint(oldLeading)
+            detailLabel?.rsd_alignToSuperview([.leading], padding: kLeadingMargin)
+        }
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override open func setDesignSystem(_ designSystem: RSDDesignSystem, with background: RSDColorTile) {
+        super.setDesignSystem(designSystem, with: background)
+        chevron?.image = chevron?.image?.rsd_applyColor(designSystem.colorRules.palette.secondary.normal.color)
+        
+        titleLabel?.font = designSystem.fontRules.font(for: .mediumHeader)
+    }
+}

--- a/Psorcast/Psorcast/StudyExternalIdRegistrationViewController.swift
+++ b/Psorcast/Psorcast/StudyExternalIdRegistrationViewController.swift
@@ -1,8 +1,8 @@
 //
-//  DataDefaults.swift
+//  StudyExternalIdRegistrationViewController.swift
 //  Psorcast
 //
-//  Copyright © 2019 Sage Bionetworks. All rights reserved.
+//  Copyright © 2018-2019 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -32,23 +32,33 @@
 //
 
 import UIKit
+import ResearchUI
+import Research
+import BridgeSDK
+import BridgeApp
 
-class DataDefaults {
+open class StudyExternalIdRegistrationStepObject: ExternalIDRegistrationStep {
+    override open func instantiateViewController(with parent: RSDPathComponent?) -> (UIViewController & RSDStepController)? {
+        return StudyExternalIdRegistrationViewController(step: self, parent: parent)
+    }
+}
+
+open class StudyExternalIdRegistrationViewController: ExternalIDRegistrationViewController {
     
-    private let currentTreatmentsKey = "CurrentTreatments"
-    private let dateSetCurrentTreatmentsKey = "DateSetCurrentTreatments"
-    
-    
-    public func setCurrentTreatments(treatmentIds: [String]) {
-        UserDefaults.standard.set(treatmentIds, forKey: currentTreatmentsKey)
-        UserDefaults.standard.set(Date(), forKey: dateSetCurrentTreatmentsKey)
+    open var profileManager: StudyProfileManager? {
+        return SBAProfileManagerObject.shared as? StudyProfileManager
     }
     
-    public func getCurrentTreatments() -> [String] {
-        return UserDefaults.standard.stringArray(forKey: currentTreatmentsKey) ?? [String]()
+    override open var nibName: String? {
+        return String(describing: ExternalIDRegistrationViewController.self)
     }
     
-    public func getDateSetCurrentTreatments() -> Date? {
-        return UserDefaults.standard.object(forKey: dateSetCurrentTreatmentsKey) as? Date
+    override open func goForward() {
+        
+        // At this point the user is signed in, and we should update their profile
+        // so we know if we should transition them to treatment selection
+        self.profileManager?.reloadData()    
+        
+        super.goForward()
     }
 }

--- a/Psorcast/Psorcast/StudyProfileManager.swift
+++ b/Psorcast/Psorcast/StudyProfileManager.swift
@@ -1,0 +1,161 @@
+//
+//  StudyProfileManager.swift
+//  Psorcast
+//
+//  Copyright © 2019 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import BridgeApp
+
+open class StudyProfileManager: SBAProfileManagerObject {
+    
+    let treatmentsProfileKey = "treatmentSelection"
+    let diagnosisProfileKey = "psoriasisStatus"
+    let symptomsProfileKey = "psoriasisSymptoms"
+    
+    let profileTasks = [RSDIdentifier.treatmentTask.rawValue]
+    
+    open var treatmentStepIdentifiers: [String] {
+        return [diagnosisProfileKey, symptomsProfileKey, treatmentsProfileKey]
+    }
+
+    override open func availablePredicate() -> NSPredicate {
+        return SBBScheduledActivity.includeTasksPredicate(with: self.profileTasks)
+    }
+    
+    open var treatmentsDate: Date? {
+        return self.report(with: RSDIdentifier.treatmentTask.rawValue)?.date
+    }
+    
+    open var treatments: [String]? {
+        return self.value(forProfileKey: treatmentsProfileKey) as? [String]
+    }
+    
+    /// The current value of treatments as an answer result
+    open var treatmentsResult: RSDAnswerResultObject? {
+        guard let treatmentsUnwrapped = self.treatments else { return nil }
+        let stringArrayType = RSDAnswerResultType(baseType: .string, sequenceType: .array, formDataType: .collection(.multipleChoice, .string), dateFormat: nil, unit: nil, sequenceSeparator: nil)
+        return RSDAnswerResultObject(identifier: treatmentsProfileKey, answerType: stringArrayType, value: treatmentsUnwrapped)
+    }
+    
+    open var diagnosis: String? {
+        return self.value(forProfileKey: diagnosisProfileKey) as? String
+    }
+    
+    /// The current value of diagnosis as an answer result
+    open var diagnosisResult: RSDAnswerResultObject? {
+        guard let diagnosisUnwrapped = self.diagnosis else { return nil }
+        return RSDAnswerResultObject(identifier: diagnosisProfileKey, answerType: .string, value: diagnosisUnwrapped)
+    }
+    
+    open var symptoms: String? {
+       return self.value(forProfileKey: symptomsProfileKey) as? String
+    }
+    
+    /// The current value of symptoms as an answer result
+    open var symptomsResult: RSDAnswerResultObject? {
+        guard let symptomsUnwrapped = self.symptoms else { return nil }
+        return RSDAnswerResultObject(identifier: symptomsProfileKey, answerType: .string, value: symptomsUnwrapped)
+    }
+    
+    /// Creates and returns the answer result for the current state of the profile key
+    open func answerResult(for profileKey: String) -> RSDAnswerResultObject? {
+        switch profileKey {
+        case treatmentsProfileKey:
+            return self.treatmentsResult
+        case symptomsProfileKey:
+            return self.symptomsResult
+        case diagnosisProfileKey:
+            return self.diagnosisResult
+        default:
+            return nil
+        }
+    }
+    
+    override open func reportCategory(for reportIdentifier: String) -> SBAReportCategory {
+        if reportIdentifier == RSDIdentifier.treatmentTask.rawValue {
+            return .timestamp
+        }
+        return super.reportCategory(for: reportIdentifier)
+    }
+    
+    override open func reportQueries() -> [SBAReportManager.ReportQuery] {
+        
+        // There is a bug in SBAReportManager where a report query will be stuck
+        // when the user is not authenticated, fix that here
+        // TODO: make a jira issue
+        if !BridgeSDK.authManager.isAuthenticated() { return [] }
+        
+        // This will include most recent for quick current treatment access
+        var queries = super.reportQueries()
+        // Also add the report query for the entire list of treatment history
+        if let treatmentQuery = queries.first(where: { $0.reportIdentifier == RSDIdentifier.treatmentTask.rawValue }) {
+            queries.append(ReportQuery(reportKey: RSDIdentifier(rawValue: treatmentQuery.reportIdentifier), queryType: .all, dateRange: nil))
+        }
+        return queries
+    }
+}
+
+extension SBAProfileSectionType {
+    /// Creates a `StudyProfileSection`.
+    public static let studySection: SBAProfileSectionType = "studySection"
+}
+
+class StudyProfileDataSource: SBAProfileDataSourceObject {
+
+    override open func decodeSection(from decoder:Decoder, with type:SBAProfileSectionType) throws -> SBAProfileSection? {
+        switch type {
+        case .studySection:
+            return try StudyProfileSection(from: decoder)
+        default:
+            return try super.decodeSection(from: decoder, with: type)
+        }
+    }
+
+}
+
+extension SBAProfileTableItemType {
+    /// Creates a `HealthInformationProfileTableItem`.
+    public static let healthInformation: SBAProfileTableItemType = "healthInformation"
+}
+
+class StudyProfileSection: SBAProfileSectionObject {
+
+    override open func decodeItem(from decoder:Decoder, with type:SBAProfileTableItemType) throws -> SBAProfileTableItem? {
+        switch type {
+        default:
+            return try super.decodeItem(from: decoder, with: type)
+        }
+    }
+}
+
+extension SBAProfileOnSelectedAction {
+    public static let healthInformationProfileAction: SBAProfileOnSelectedAction = "healthInformationProfileAction"
+}
+

--- a/Psorcast/Psorcast/StudyProfileManager.swift
+++ b/Psorcast/Psorcast/StudyProfileManager.swift
@@ -36,13 +36,14 @@ import BridgeApp
 open class StudyProfileManager: SBAProfileManagerObject {
     
     let treatmentsProfileKey = "treatmentSelection"
+    let treatmentsDateProfileKey = "treatmentSelectionDate"
     let diagnosisProfileKey = "psoriasisStatus"
     let symptomsProfileKey = "psoriasisSymptoms"
     
     let profileTasks = [RSDIdentifier.treatmentTask.rawValue]
     
     open var treatmentStepIdentifiers: [String] {
-        return [diagnosisProfileKey, symptomsProfileKey, treatmentsProfileKey]
+        return [diagnosisProfileKey, symptomsProfileKey, treatmentsProfileKey, treatmentsDateProfileKey]
     }
 
     override open func availablePredicate() -> NSPredicate {
@@ -50,7 +51,13 @@ open class StudyProfileManager: SBAProfileManagerObject {
     }
     
     open var treatmentsDate: Date? {
-        return self.report(with: RSDIdentifier.treatmentTask.rawValue)?.date
+        guard let timeIntervalSince1970 = self.value(forProfileKey: treatmentsDateProfileKey) as? Double else { return nil }
+        return Date(timeIntervalSince1970: timeIntervalSince1970)
+    }
+    
+    open var treatmentsDateResult: RSDAnswerResultObject? {
+        guard let treatmentsDateUnwrapped = self.treatmentsDate else { return nil }
+        return RSDAnswerResultObject(identifier: treatmentsDateProfileKey, answerType: .decimal, value: treatmentsDateUnwrapped)
     }
     
     open var treatments: [String]? {

--- a/Psorcast/Psorcast/StudyProfileManager.swift
+++ b/Psorcast/Psorcast/StudyProfileManager.swift
@@ -120,6 +120,26 @@ open class StudyProfileManager: SBAProfileManagerObject {
         }
         return queries
     }
+    
+    override open func didUpdateReports(with newReports: [SBAReport]) {
+        self.reports = Set(self.reports.sorted(by: { $0.date < $1.date }))
+        super.didUpdateReports(with: newReports)
+    }
+    
+    override open func decodeItem(from decoder: Decoder, with type: SBAProfileItemType) throws -> SBAProfileItem? {
+        
+        switch (type) {
+        case .report:
+            // TODO remove once this is merged https://github.com/Sage-Bionetworks/BridgeApp-Apple-SDK/pull/184
+            let item = try HealthProfileItem(from: decoder)
+            item.reportManager = self
+            return item
+    
+        default:
+            break
+        }
+        return try super.decodeItem(from: decoder, with: type)
+    }
 }
 
 extension SBAProfileSectionType {
@@ -148,6 +168,7 @@ extension SBAProfileTableItemType {
 class StudyProfileSection: SBAProfileSectionObject {
 
     override open func decodeItem(from decoder:Decoder, with type:SBAProfileTableItemType) throws -> SBAProfileTableItem? {
+        
         switch type {
         default:
             return try super.decodeItem(from: decoder, with: type)
@@ -158,4 +179,3 @@ class StudyProfileSection: SBAProfileSectionObject {
 extension SBAProfileOnSelectedAction {
     public static let healthInformationProfileAction: SBAProfileOnSelectedAction = "healthInformationProfileAction"
 }
-

--- a/Psorcast/Psorcast/StudyTaskFactory.swift
+++ b/Psorcast/Psorcast/StudyTaskFactory.swift
@@ -78,3 +78,131 @@ extension SBAProfileDataSourceType {
     /// Defaults to a `studyProfileDataSource`.
     public static let studyProfileDataSource: SBAProfileDataSourceType = "studyProfileDataSource"
 }
+
+// Temporary class until https://github.com/Sage-Bionetworks/BridgeApp-Apple-SDK/pull/184
+
+open class HealthProfileItem: SBAProfileItem {
+    
+    private enum CodingKeys: String, CodingKey {
+        case profileKey, _sourceKey = "sourceKey", _demographicKey = "demographicKey", demographicSchema,
+        _clientDataIsItem = "clientDataIsItem", itemType, _readonly = "readonly", type
+    }
+    
+    var _sourceKey: String?
+    public var sourceKey: String {
+        get {
+            return self._sourceKey ?? self.profileKey
+        }
+        set {
+            self._sourceKey = newValue
+        }
+    }
+    
+    var _demographicKey: String?
+    public var demographicKey: String {
+        get {
+            return self._demographicKey ?? self.profileKey
+        }
+        set {
+            self._demographicKey = newValue
+        }
+    }
+    
+    var _readonly: Bool?
+    public var readonly: Bool {
+        get {
+            return self._readonly ?? false
+        }
+        set {
+            self._readonly = newValue
+        }
+    }
+    
+    /// profileKey is used to access a specific profile item, and so must be unique across all SBAProfileItems
+    /// within an app.
+    public var profileKey: String
+    
+    /// demographicSchema is an optional schema identifier to mark a profile item as being part of the indicated
+    /// demographic data upload schema.
+    public var demographicSchema: String?
+    
+    /// If clientDataIsItem is true, the report's clientData field is assumed to contain the item value itself.
+    ///
+    /// If clientDataIsItem is false, the report's clientData field is assumed to be a dictionary in which
+    /// the item value is stored and retrieved via the demographicKey.
+    ///
+    /// The default value is false.
+    public var _clientDataIsItem: Bool?
+    public var clientDataIsItem: Bool {
+        get {
+            return self._clientDataIsItem ?? false
+        }
+        set {
+            self._clientDataIsItem = newValue
+        }
+    }
+
+    /// itemType specifies what type to store the profileItem's value as. Defaults to String if not otherwise specified.
+    public var itemType: RSDFormDataType
+    
+    /// The class type to which to deserialize this profile item.
+    public var type: SBAProfileItemType
+    
+    /// The report manager to use when storing and retrieving the item's value.
+    ///
+    /// By default, the profile manager that decodes this item will point this property at itself. If you point it at
+    /// a different report manager, you will need to ensure that report manager is set up to handle the relevant report.
+    public weak var reportManager: SBAReportManager?
+    
+    public func storedValue(forKey key: String) -> Any? {
+        guard let reportManager = self.reportManager,
+            // This is the most recent report's client data.
+            let clientData = reportManager.report(with: RSDIdentifier(rawValue: key).rawValue)?.clientData
+            else {
+                return nil
+        }
+        var json = clientData
+        if !self.clientDataIsItem {
+            guard let dict = clientData as? NSDictionary,
+                    let propJson = dict[self.demographicKey] as? SBBJSONValue
+                else {
+                    return nil
+            }
+            json = propJson
+        }
+        
+        return self.commonBridgeJsonToItemType(jsonVal: json)
+    }
+    
+    public func setStoredValue(_ newValue: Any?) {
+        guard !self.readonly, let reportManager = self.reportManager else { return }
+        let previousReport = reportManager.reports
+            .sorted(by: { $0.date < $1.date })
+            .last(where: { $0.reportKey == RSDIdentifier(rawValue: self.sourceKey) })
+        var clientData : SBBJSONValue = NSNull()
+        if self.clientDataIsItem {
+            clientData = self.commonItemTypeToBridgeJson(val: newValue)
+        } else {
+            var clientJsonDict = previousReport?.clientData as? [String : Any] ?? [String : Any] ()
+            clientJsonDict[self.demographicKey] = self.commonItemTypeToBridgeJson(val: newValue)
+            clientData = clientJsonDict as NSDictionary
+        }
+        let report = reportManager.newReport(reportIdentifier: self.sourceKey, date: Date(), clientData: clientData)
+        reportManager.saveReport(report)
+    }
+    
+    /// The value property is used to get and set the profile item's value in whatever internal data
+    /// storage is used by the implementing type. Setting the value on a non-readonly profile item causes
+    /// a notification to be posted.
+    public var value: Any? {
+        get {
+            return self.storedValue(forKey: sourceKey)
+        }
+        set {
+            guard !readonly else { return }
+            self.setStoredValue(newValue)
+            let updatedItems: [String: Any?] = [self.profileKey: newValue]
+            NotificationCenter.default.post(name: .SBAProfileItemValueUpdated, object: self, userInfo: [SBAProfileItemUpdatedItemsKey: updatedItems])
+        }
+    }    
+}

--- a/Psorcast/Psorcast/StudyTaskFactory.swift
+++ b/Psorcast/Psorcast/StudyTaskFactory.swift
@@ -38,6 +38,19 @@ extension RSDStepType {
 }
 
 open class StudyTaskFactory: TaskFactory {
+    
+    override open func decodeProfileManager(from decoder: Decoder) throws -> SBAProfileManager {
+        let typeName: String = try decoder.factory.typeName(from: decoder) ?? SBAProfileManagerType.profileManager.rawValue
+        let type = SBAProfileManagerType(rawValue: typeName)
+        
+        // Inject our own custom profile manager
+        if type == .profileManager {
+            return try StudyProfileManager(from: decoder)
+        }
+        
+        return try super.decodeProfileManager(from: decoder)
+    }
+    
     /// Override the base factory to vend Psorcast specific step objects.
     override open func decodeStep(from decoder: Decoder, with type: RSDStepType) throws -> RSDStep? {
         switch type {
@@ -47,4 +60,21 @@ open class StudyTaskFactory: TaskFactory {
             return try super.decodeStep(from: decoder, with: type)
         }
     }
+    
+    override open func decodeProfileDataSource(from decoder: Decoder) throws -> SBAProfileDataSource {
+        let type = try decoder.factory.typeName(from: decoder) ?? SBAProfileDataSourceType.studyProfileDataSource.rawValue
+        let dsType = SBAProfileDataSourceType(rawValue: type)
+
+        switch dsType {
+        case .studyProfileDataSource:
+            return try StudyProfileDataSource(from: decoder)
+        default:
+            return try super.decodeProfileDataSource(from: decoder)
+        }
+    }
+}
+
+extension SBAProfileDataSourceType {
+    /// Defaults to a `studyProfileDataSource`.
+    public static let studyProfileDataSource: SBAProfileDataSourceType = "studyProfileDataSource"
 }

--- a/Psorcast/Psorcast/Treatment.json
+++ b/Psorcast/Psorcast/Treatment.json
@@ -1,6 +1,7 @@
 {
-    "identifier": "Onboarding",
-    "taskIdentifier" : "Onboarding",
+    "identifier": "Treatment",
+    "taskIdentifier" : "Treatment",
+    "schemaIdentifier" : "Treatment",
     "progressMarkers":[],
     "steps":
     [
@@ -8,13 +9,6 @@
             "identifier": "psoriasisStatus",
             "type": "form",
             "title": "Has a doctor diagnosed you with psoriasis or psoriatic arthritis?",
-            "actions":{
-                "skip": {
-                    "type": "navigation",
-                    "buttonTitle" : "Don’t have either",
-                    "skipToIdentifier": "treatmentsSelection"
-                }
-            },
             "inputFields": [
                 {
                     "uiHint": "list",
@@ -22,15 +16,19 @@
                     "choices": [
                         {
                             "text": "Psoriasis",
-                            "value": "psoriasis"
+                            "value": "Psoriasis"
                         },
                         {
                             "text": "Psoriatic Arthritis",
-                            "value": "psoriatic_arthritis"
+                            "value": "Psoriatic Arthritis"
                         },
                         {
                             "text": "Both of the above",
-                            "value": "both",
+                            "value": "Psoriasis, Psoriatic Arthritis",
+                        },
+                        {
+                            "text": "I don’t have either",
+                            "value": "I do not have psoriasis",
                         }
                     ]
                 }
@@ -40,13 +38,6 @@
             "identifier": "psoriasisSymptoms",
             "type": "form",
             "title": "What kind of symptoms do you currently experience?",
-            "actions":{
-                "skip": {
-                    "type": "navigation",
-                    "buttonTitle" : "Don’t have either",
-                    "skipToIdentifier": "treatmentsSelection"
-                }
-            },
             "inputFields": [
                 {
                     "uiHint": "list",
@@ -54,15 +45,21 @@
                     "choices": [
                         {
                             "text": "Skin symptoms",
-                            "value": "skin"
+                            "detail": "Red, scaling, itch, or changes to nails",
+                            "value": "Skin symptoms"
                         },
                         {
                             "text": "Painful or swollen joints",
-                            "value": "painful_joints"
+                            "detail": "Swollen, red, warm, painful or stiff joints",
+                            "value": "Painful or swollen joints"
                         },
                         {
                             "text": "Both of the above",
-                            "value": "both",
+                            "value": "Skin sympotms, Painful or swollen joints",
+                        },
+                        {
+                            "text": "I don’t have either",
+                            "value": "I do not have symptoms",
                         }
                     ]
                 }

--- a/Psorcast/Psorcast/TreatmentSelectionStepViewController.swift
+++ b/Psorcast/Psorcast/TreatmentSelectionStepViewController.swift
@@ -459,6 +459,10 @@ public class TreatmentSelectionStepViewController: RSDStepViewController, UITabl
     }
     
     override open func goForward() {
+        // Save when the user has changed their treatments
+        let dateAnswer = RSDAnswerResultObject(identifier: "\(self.step.identifier)Date", answerType: .decimal, value: Date().timeIntervalSince1970)
+        _ = self.stepViewModel.parent?.taskResult.appendStepHistory(with: dateAnswer)
+        
         /// Save a string list of the multi-choice answer identifiers
         let answer = Array(self.currentTreatmentsIds)
         let stringArrayType = RSDAnswerResultType(baseType: .string, sequenceType: .array, formDataType: .collection(.multipleChoice, .string), dateFormat: nil, unit: nil, sequenceSeparator: nil)

--- a/Psorcast/Psorcast/TryItFirstTaskTableViewController.swift
+++ b/Psorcast/Psorcast/TryItFirstTaskTableViewController.swift
@@ -151,10 +151,7 @@ class TryItFirstTaskTableViewController: UIViewController, UICollectionViewDataS
         self.runTask(at: itemIndex)
     }
     
-    func runTask(at itemIndex: Int) {
-        // Initiate task factory
-        RSDFactory.shared = StudyTaskFactory()
-        
+    func runTask(at itemIndex: Int) {        
         // Work-around fix for permission bug
         // This will force the overview screen to check permission state every time
         // Usually research framework caches it and the state becomes invalid

--- a/Psorcast/Psorcast/WelcomeVideoViewController.swift
+++ b/Psorcast/Psorcast/WelcomeVideoViewController.swift
@@ -126,7 +126,7 @@ class WelcomeVideoViewController: UIViewController {
     
     @IBAction func getStartedTapped() {
         guard let appDelegate = AppDelegate.shared as? AppDelegate else { return }
-        appDelegate.showOnboardingScreens(animated: true)
+        appDelegate.showSignInViewController(animated: true)
     }
     
     @IBAction func tryItFirstTapped() {

--- a/Psorcast/PsorcastValidation/ExternalIDRegistrationViewController.swift
+++ b/Psorcast/PsorcastValidation/ExternalIDRegistrationViewController.swift
@@ -37,9 +37,9 @@ import Research
 import BridgeSDK
 import BridgeApp
 
-class ExternalIDRegistrationStep : RSDUIStepObject, RSDStepViewControllerVendor, RSDNavigationSkipRule {
+open class ExternalIDRegistrationStep : RSDUIStepObject, RSDStepViewControllerVendor, RSDNavigationSkipRule {
     
-    func shouldSkipStep(with result: RSDTaskResult?, isPeeking: Bool) -> Bool {
+    open func shouldSkipStep(with result: RSDTaskResult?, isPeeking: Bool) -> Bool {
         return BridgeSDK.authManager.isAuthenticated()
     }    
     
@@ -48,7 +48,7 @@ class ExternalIDRegistrationStep : RSDUIStepObject, RSDStepViewControllerVendor,
     }
 }
 
-class ExternalIDRegistrationViewController: RSDStepViewController, UITextFieldDelegate {
+open class ExternalIDRegistrationViewController: RSDStepViewController, UITextFieldDelegate {
     
     /// The image header
     @IBOutlet public var imageView: UIImageView!
@@ -66,7 +66,7 @@ class ExternalIDRegistrationViewController: RSDStepViewController, UITextFieldDe
     @IBOutlet public var submitButton: RSDRoundedButton!
     
     /// The loading spinner
-    @IBOutlet public var loadingSpinner: UIActivityIndicatorView!
+    @IBOutlet public var loadingSpinner: UIActivityIndicatorView!        
     
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -121,7 +121,7 @@ class ExternalIDRegistrationViewController: RSDStepViewController, UITextFieldDe
         return self.textField.text
     }
     
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         if let text = textField.text,
             let textRange = Range(range, in: text) {
             let updatedText = text.replacingCharacters(in: textRange, with: string)
@@ -130,7 +130,7 @@ class ExternalIDRegistrationViewController: RSDStepViewController, UITextFieldDe
         return true
     }
     
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         return self.textField.endEditing(false)
     }
     

--- a/Psorcast/PsorcastValidation/MotorControl+Bridge.swift
+++ b/Psorcast/PsorcastValidation/MotorControl+Bridge.swift
@@ -36,6 +36,8 @@ import BridgeApp
 import MotorControl
 
 public extension RSDIdentifier {
+    
+    // Measuring tasks
     static let walkingTask: RSDIdentifier = MCTTaskIdentifier.walk30Seconds.identifier    
     static let handImagingTask: RSDIdentifier = "HandImaging"
     static let footImagingTask: RSDIdentifier = "FootImaging"
@@ -45,6 +47,9 @@ public extension RSDIdentifier {
     static let psoriasisAreaPhotoTask: RSDIdentifier = "PsoriasisAreaPhoto"
     static let psoriasisDrawTask: RSDIdentifier = "PsoriasisDraw"
     static let digitalJarOpenTask: RSDIdentifier = "DigitalJarOpen"
+    
+    // Profile tasks
+    static let treatmentTask: RSDIdentifier = "Treatment"
 }
 
 extension MCTTaskInfo : SBAActivityInfo {

--- a/Psorcast/PsorcastValidation/Psorcast.strings
+++ b/Psorcast/PsorcastValidation/Psorcast.strings
@@ -111,3 +111,5 @@
 "INSIGHT_UNLOCKED_TITLE" = "You unlocked your Psorcast Insight";
 "INSIGHT_UNLOCKED_TEXT" = "View Your Insight";
 
+"PROFILE_TITLE" = "Your Profile";
+


### PR DESCRIPTION
This PR requires you to clear your device data and do a fresh sign up or sign so the app can collect the treatments/symptoms/diagnosis again and store them in study reports instead of local data.

I decided to take the time and utilize Research framework's ProfileManager and ProfileDataSource to store the treatments data.  This required about 2x more time then if I would have wrote it from scratch, but it should save us a lot of time in the future when maintaining it and add the additional profile items for the app.

The setup for the profile manager and profile data source JSON setup exists on Psorcast Bridge Study Manager's AppConfig  as "Config Elements". See config elements on BSM under App Support section.

Those are sent down to the app on first start up, so you will want to delete the app, clear the data, and re-install the app to get the updated app config, as stated earlier.

There were a few bugs in the Research framework code that I found while developing our particular solution (keeping the treatment survey together, but being able to edit each question answer individually, the main fix can be tracked here https://github.com/Sage-Bionetworks/BridgeApp-Apple-SDK/pull/184 this is not blocked by the PR, but a few 100 lines of code can be removed from our repo once this is merged and pointed at.

See Jira issue for the app working.