### PR TITLE
PSR-290

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -77,6 +77,8 @@
 		CB81C92E242D3AB100A84886 /* MeasureTabViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81C92D242D3AB100A84886 /* MeasureTabViewControllerTests.swift */; };
 		CB85FB52235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85FB51235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift */; };
 		CB85FB56235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85FB55235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift */; };
+		CB89B895246C7B3200567345 /* DeepDiveTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB89B88C246C7B3200567345 /* DeepDiveTableViewController.swift */; };
+		CB89B897246C825A00567345 /* WebImageInstructionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB89B896246C825A00567345 /* WebImageInstructionViewController.swift */; };
 		CB8AE6FD233FB53400F5F8AC /* PsoriasisDraw.json in Resources */ = {isa = PBXBuildFile; fileRef = CB8AE6FC233FB53400F5F8AC /* PsoriasisDraw.json */; };
 		CB8AE6FF233FBA1800F5F8AC /* PsoriasisDrawImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB8AE6FE233FBA1800F5F8AC /* PsoriasisDrawImageView.swift */; };
 		CB8AE701233FBA5E00F5F8AC /* PsoriasisDrawStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB8AE700233FBA5E00F5F8AC /* PsoriasisDrawStepViewController.swift */; };
@@ -431,6 +433,8 @@
 		CB81C92D242D3AB100A84886 /* MeasureTabViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeasureTabViewControllerTests.swift; sourceTree = "<group>"; };
 		CB85FB51235F505300FDC59B /* PsoriasisDrawTaskResultProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PsoriasisDrawTaskResultProcessor.swift; sourceTree = "<group>"; };
 		CB85FB55235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedIdentifiersResultObject.swift; sourceTree = "<group>"; };
+		CB89B88C246C7B3200567345 /* DeepDiveTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeepDiveTableViewController.swift; sourceTree = "<group>"; };
+		CB89B896246C825A00567345 /* WebImageInstructionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebImageInstructionViewController.swift; sourceTree = "<group>"; };
 		CB8AE6FC233FB53400F5F8AC /* PsoriasisDraw.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PsoriasisDraw.json; sourceTree = "<group>"; };
 		CB8AE6FE233FBA1800F5F8AC /* PsoriasisDrawImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PsoriasisDrawImageView.swift; sourceTree = "<group>"; };
 		CB8AE700233FBA5E00F5F8AC /* PsoriasisDrawStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PsoriasisDrawStepViewController.swift; sourceTree = "<group>"; };
@@ -655,6 +659,8 @@
 				CB8F2925245BD14C00ABE5B3 /* FilterTreatmentViewController.swift */,
 				CB8F2920245BD14C00ABE5B3 /* FilterTreatmentViewController.xib */,
 				CB2219D5246132D2007546CD /* PastInsightsViewController.swift */,
+				CB89B88C246C7B3200567345 /* DeepDiveTableViewController.swift */,
+				CB89B896246C825A00567345 /* WebImageInstructionViewController.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -1330,6 +1336,7 @@
 				CBDCDCA823F3849E00E5CEB8 /* PsoriasisAreaPhotoCompletionStepViewController.swift in Sources */,
 				CBDCDC9F23F3849E00E5CEB8 /* JointPainCompletionStepViewController.swift in Sources */,
 				CBDCDCB223F3849E00E5CEB8 /* DigitalJarOpenStepViewController.swift in Sources */,
+				CB89B897246C825A00567345 /* WebImageInstructionViewController.swift in Sources */,
 				CBDCDCAD23F3849E00E5CEB8 /* PsoriasisDrawResultObject.swift in Sources */,
 				CBDCDCB723F384A400E5CEB8 /* TaskFactory.swift in Sources */,
 				CBDCDCC223F3855300E5CEB8 /* BuildDateUtil.m in Sources */,
@@ -1374,6 +1381,7 @@
 				CB7CF2422400BF10003E02A5 /* WelcomeVideoViewController.swift in Sources */,
 				CBDCDC9823F3849E00E5CEB8 /* ReviewCaptureStepViewController.swift in Sources */,
 				CBAA09CF243E4F5500D63CCD /* TreatmentSelectionResultObject.swift in Sources */,
+				CB89B895246C7B3200567345 /* DeepDiveTableViewController.swift in Sources */,
 				CB4794F72426B3D800D5A7E6 /* TreatmentSelectionTableViewCell.swift in Sources */,
 				CB8F2927245BD14C00ABE5B3 /* FilterTreatmentViewController.swift in Sources */,
 				CBDCDCA723F3849E00E5CEB8 /* PsoriasisAreaPhotoImageView.swift in Sources */,
@@ -1681,7 +1689,7 @@
 				CODE_SIGN_ENTITLEMENTS = Psorcast/Psorcast.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = KA9Z8R6M6K;
 				INFOPLIST_FILE = Psorcast/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1704,7 +1712,7 @@
 				CODE_SIGN_ENTITLEMENTS = Psorcast/Psorcast.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = KA9Z8R6M6K;
 				INFOPLIST_FILE = Psorcast/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Psorcast/Psorcast/AppDelegate.swift
+++ b/Psorcast/Psorcast/AppDelegate.swift
@@ -142,6 +142,10 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
         self.transition(to: vc, state: .consent, animated: true)
     }
     
+    override open func instantiateBridgeConfiguration() -> SBABridgeConfiguration {
+        return StudyBridgeConfiguration()
+    }
+    
     func showTryItFirstIntroScreens(animated: Bool) {
         guard self.rootViewController?.state != .main else { return }
         

--- a/Psorcast/Psorcast/DeepDiveTableViewController.swift
+++ b/Psorcast/Psorcast/DeepDiveTableViewController.swift
@@ -1,0 +1,108 @@
+//
+//  DeepDiveTableViewController.swift
+//  Psorcast
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import ResearchUI
+
+open class DeepDiveTableViewController: UITableViewController, RSDTaskViewControllerDelegate {
+        
+    open var deepDiveItems = [DeepDiveItem]()
+    
+    let headerHeight = CGFloat(82)
+    let headerPadding = CGFloat(16)
+    
+    open var profileManager = (AppDelegate.shared as? AppDelegate)?.profileManager
+    
+    let design = AppDelegate.designSystem
+    let white = RSDColorTile(RSDColor.white, usesLightStyle: false)
+    
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.tableView.tableHeaderView = self.createTableViewHeader()
+        self.tableView.allowsSelection = true
+        self.tableView.separatorStyle = .none
+        self.tableView.register(RSDSelectionTableViewCell.self,
+                                forCellReuseIdentifier: String(describing: RSDSelectionTableViewCell.self))
+    }
+    
+    func createTableViewHeader() -> UIView {
+        let header = UIView(frame: CGRect(x: 0, y: 0, width: self.view.bounds.width, height: self.headerHeight))
+        
+        let backButton = UIButton(type: .system)
+        backButton.setImage(UIImage(named: "BackDark"), for: .normal)
+        backButton.addTarget(self, action: #selector(self.backButtonTapped), for: .touchUpInside)
+        
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        header.addSubview(backButton)
+        
+        backButton.rsd_alignToSuperview([.leading, .top, .bottom], padding: headerPadding)
+        
+        return header
+    }
+    
+    @objc func backButtonTapped() {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    public override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.deepDiveItems.count
+    }
+    
+    public override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: String(describing: RSDSelectionTableViewCell.self), for: indexPath)
+        guard let customCell = cell as? RSDSelectionTableViewCell else {
+            return cell
+        }
+        let item = self.deepDiveItems[indexPath.row]
+        customCell.titleLabel?.text = item.title ?? item.task.identifier
+        return customCell
+    }
+    
+    public override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let item = self.deepDiveItems[indexPath.row]
+        let vc = RSDTaskViewController(task: item.task)
+        vc.delegate = self
+        self.show(vc, sender: self)
+    }
+    
+    public func taskController(_ taskController: RSDTaskController, didFinishWith reason: RSDTaskFinishReason, error: Error?) {
+//        self.profileManager?.taskController(taskController, didFinishWith: reason, error: error)
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    public func taskController(_ taskController: RSDTaskController, readyToSave taskViewModel: RSDTaskViewModel) {
+        //self.profileManager?.taskController(taskController, readyToSave: taskViewModel)
+    }
+}

--- a/Psorcast/Psorcast/MasterScheduleManager.swift
+++ b/Psorcast/Psorcast/MasterScheduleManager.swift
@@ -51,7 +51,7 @@ open class MasterScheduleManager : SBAScheduleManager {
     /// The profile manager for the app, could also be a standard variable, but lets keep it connected to the one source of truth
     open weak var profileManager: StudyProfileManager? {
         return (AppDelegate.shared as? AppDelegate)?.profileManager
-    }
+    }        
     
     /// The date available for unit test override
     open func nowDate() -> Date {
@@ -286,6 +286,44 @@ open class MasterScheduleManager : SBAScheduleManager {
     open func diagnosis() -> String? {
         return self.profileManager?.diagnosis
     }
+            
+    /// THe list of profile deep dive tasks
+    open var deepDiveList: DeepDiveList? {
+        guard let studyConfig = SBABridgeConfiguration.shared as? StudyBridgeConfiguration else { return nil }
+        return studyConfig.deepDiveList
+    }
+    
+    open func deepDiveTask(for identifier: String) -> RSDTask? {
+        return SBABridgeConfiguration.shared.task(for: identifier)
+    }
+    
+    open var deepDiveTaskList: [RSDTask] {
+        guard let list = self.deepDiveList?.sortOrder else { return [] }
+        var taskList = [RSDTask]()
+        for item in list {
+            if let task = self.deepDiveTask(for: item.identifier) {
+                taskList.append(task)
+            }
+        }
+        return taskList
+    }
+    
+    open var deepDiveTaskItems: [DeepDiveItem] {
+        guard let sortOrder = self.deepDiveList?.sortOrder else { return [] }
+        let taskList = self.deepDiveTaskList
+        var items = [DeepDiveItem]()
+        for item in sortOrder {
+            if let matchingTask = taskList.first(where: { $0.identifier == item.identifier }) {
+                items.append(DeepDiveItem(title: item.title, task: matchingTask))
+            }
+        }
+        return items
+    }
+}
+
+public struct DeepDiveItem {
+    public var title: String?
+    public var task: RSDTask
 }
 
 public enum StudyScheduleFrequency {

--- a/Psorcast/Psorcast/ProfileTabViewController.swift
+++ b/Psorcast/Psorcast/ProfileTabViewController.swift
@@ -138,6 +138,12 @@ class ProfileTabViewController: UIViewController, UITableViewDelegate, UITableVi
         return cell
     }
     
+    func showDeepDiveViewController() {
+        let vc = DeepDiveTableViewController()
+        vc.deepDiveItems = MasterScheduleManager.shared.deepDiveTaskItems
+        self.present(vc, animated: true, completion: nil)
+    }
+    
     public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         guard self.profileDataSource?.title(for: section) != nil else { return CGFloat.leastNormalMagnitude }
         return UITableView.automaticDimension
@@ -184,6 +190,8 @@ class ProfileTabViewController: UIViewController, UITableViewDelegate, UITableVi
                 let vc = PastInsightsViewController()
                 vc.insightItems = self.profileManager?.pastInsightItems ?? []
                 self.show(vc, sender: self)
+            } else if profileItem.profileItemKey == StudyProfileManager.deepDiveProfileIdentifier {
+                self.showDeepDiveViewController()
             } else if let vc = self.profileManager?.instantiateSingleQuestionTreatmentTaskController(for: profileItem.profileItemKey) {
                 vc.delegate = self
                 self.show(vc, sender: self)

--- a/Psorcast/Psorcast/StudyProfileManager.swift
+++ b/Psorcast/Psorcast/StudyProfileManager.swift
@@ -70,7 +70,9 @@ open class StudyProfileManager: SBAProfileManagerObject {
     public static let diagnosisNoneAnswer = "I do not have psoriasis"
     public static let diagnosisPsoriasisAnswer = "Psoriasis"
     public static let diagnosisArthritisAnswer = "Psoriatic Arthritis"
-    public static let diagnosisBothAnswer = "Psoriasis, Psoriatic Arthritis"    
+    public static let diagnosisBothAnswer = "Psoriasis, Psoriatic Arthritis"
+    
+    public static let deepDiveProfileIdentifier = "DeepDive"
     
     /// The date formatter for when you want to encode/decode answer dates in the profile
     public static func profileDateFormatter() -> DateFormatter {

--- a/Psorcast/Psorcast/WebImageInstructionViewController.swift
+++ b/Psorcast/Psorcast/WebImageInstructionViewController.swift
@@ -1,0 +1,116 @@
+//
+//  WebImageInstructionViewController.swift
+//  Psorcast
+//
+//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+import ResearchUI
+import SDWebImage
+
+open class WebImageInstructionStepObject: RSDUIStepObject, RSDStepViewControllerVendor {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case imageUrl
+    }
+    
+    public var imageUrl: String?
+    
+    /// Default type is `.webImageInstruction`.
+    open override class func defaultType() -> RSDStepType {
+        return .webImageInstruction
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        if container.contains(.imageUrl) {
+            self.imageUrl = try container.decode(String.self, forKey: .imageUrl)
+        }
+        
+        try super.init(from: decoder)
+    }
+    
+    required public init(identifier: String, type: RSDStepType? = nil) {
+        super.init(identifier: identifier, type: type)
+    }
+    
+    /// Override to set the properties of the subclass.
+    override open func copyInto(_ copy: RSDUIStepObject) {
+        super.copyInto(copy)
+        guard let subclassCopy = copy as? WebImageInstructionStepObject else {
+            assertionFailure("Superclass implementation of the `copy(with:)` protocol should return an instance of this class.")
+            return
+        }
+        subclassCopy.imageUrl = self.imageUrl
+    }
+    
+    public func instantiateViewController(with parent: RSDPathComponent?) -> (UIViewController & RSDStepController)? {
+        return WebImageInstructionViewController(step: self, parent: parent)
+    }
+}
+
+open class WebImageInstructionViewController: RSDInstructionStepViewController {
+    
+    let placeholder = UIImage(named: "InsightPlaceholder")
+    
+    open var webImageStep: WebImageInstructionStepObject? {
+        return self.step as? WebImageInstructionStepObject
+    }
+    
+    override open func setupHeader(_ header: RSDStepNavigationView) {
+        super.setupHeader(header)
+        
+        self.navigationHeader?.imageView?.contentMode = .scaleAspectFit
+        if let urlStr = self.webImageStep?.imageUrl,
+            let url = URL(string: urlStr) {
+            self.navigationHeader?.imageView?.sd_imageIndicator = SDWebImageActivityIndicator.gray
+            self.navigationHeader?.imageView?.sd_setImage(with: url, placeholderImage: placeholder, options: [.progressiveLoad, .highPriority], completed: { (image, error, cacheType, url) in
+                let width = self.navigationHeader?.imageView?.bounds.width ?? 0
+                let aspectRatio =  (image?.size.height ?? 0) / (image?.size.width ?? 1)
+                let height = width * aspectRatio
+                DispatchQueue.main.async {
+                    self.navigationHeader?.imageView?.superview?.heightConstaint?.constant = height
+                    self.navigationHeader?.layoutIfNeeded()
+                }
+            })
+        }
+    }
+}
+
+extension UIView {
+    var heightConstaint: NSLayoutConstraint? {
+        get {
+            return constraints.first(where: {
+                $0.firstAttribute == .height && $0.relation == .equal
+            })
+        }
+        set { setNeedsLayout() }
+    }
+}


### PR DESCRIPTION
First draft of adding deep dive surveys to the profile screen.  I added 3 starter surveys in Bridge Study Manager ConfigElements.  The list of deep dive surveys are prioritized by another ConfigElement called "DeepDiveList" which we can also used to control when we "nudge" the user to complete them.  I came up with a few ideas on how we could implement the "nudges".  See the DeepDiveList config element below:

```
{
  "catType": "deepDiveList",
  "sortOrder": [
    {
      "identifier": "DeepDiveTest1",
      "title": "Background Survey"
    },
    {
      "identifier": "DeepDiveTest2",
      "title": "Daily Life Survey"
    },
    {
      "identifier": "DeepDiveTest3",
      "title": "COVID-19 Survey"
    }
  ],
  "nudgeList": [
    {
      "identifier": "DeepDiveTest1",
      "afterViewingInsight": "InsightId",
      "afterInsightCount": 3,
      "afterNumberOfDays": 7,
      "afterCompleting": "PsoriasisDraw"
    }
  ]
} 
```
