### PR TITLE
PSR-301

### DIFF
--- a/Psorcast/PsorcastValidation/PsoriasisDrawStepViewController.swift
+++ b/Psorcast/PsorcastValidation/PsoriasisDrawStepViewController.swift
@@ -81,7 +81,18 @@ open class PsoriasisDrawStepViewController: RSDStepViewController, ProcessorFini
     
     /// The line width is proportional to the screen width
     open var lineWidth: CGFloat {
-        return (CGFloat(5) / CGFloat(375)) * self.view.frame.width
+        // We need to make sure that the line width is the same for all participants
+        // Calculate how much the image was scaled from the original
+        
+        guard let srcImageWidth = self.imageView.image?.size.width, srcImageWidth > 0,
+            let scaledImageWidth = self.imageView.lastAspectFitRect?.width else {
+            return 0
+        }
+        
+        let lineWidthRatio = scaledImageWidth / srcImageWidth
+        let penSize = CGFloat(5) * lineWidthRatio
+        
+        return penSize
     }
     
     /// Processing queue for saving camera
@@ -119,6 +130,11 @@ open class PsoriasisDrawStepViewController: RSDStepViewController, ProcessorFini
         self.initializeImages()
         self.imageView.debuggingZones = self.debuggingZones
         self.imageView?.regionZonesForDebugging = self.drawStep?.regionMap?.zones ?? []
+    }
+    
+    override open func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        self.imageView.touchDrawableView?.lineWidth = self.lineWidth
     }
     
     func initializeImages() {


### PR DESCRIPTION
Update line width to be based on aspect scale instead of the phone-width.

As it turns out, Stockard made the images all have a width of 375, so they fit nicely on all the iPhones (which usually have scaled pixel width of 375 as well) so, testing on multiple devices always gave me a line width of 5, which matched what well across the board.  However, using the scaled aspect ratio of the image is better in the long term and should guarantee we always have a proportional pen size to image size.