### PR TITLE
Validation bug fix

### DIFF
--- a/Psorcast/PsorcastValidation/ReviewCaptureStepViewController.swift
+++ b/Psorcast/PsorcastValidation/ReviewCaptureStepViewController.swift
@@ -136,12 +136,16 @@ open class ReviewCaptureStepViewController: RSDStepViewController {
     
     override open func goForward() {
         
-        // If the user accepted the photo, we should save it for overlay use later
-        if let imageId = self.reviewCaptureStep?.imageIdentifier,
-            let imageData = self.navigationHeader?.imageView?.image?.pngData(),
-            let imageDefaults = (AppDelegate.shared as? AppDelegate)?.imageDefaults {
-            imageDefaults.filterImageAndSave(with: imageId, pngData: imageData)
-        }
+        #if VALIDATION
+            // No-op on validation, as we do not need the edge detected overlay
+        #else
+            // If the user accepted the photo, we should save it for overlay use later
+            if let imageId = self.reviewCaptureStep?.imageIdentifier,
+                let imageData = self.navigationHeader?.imageView?.image?.pngData(),
+                let imageDefaults = (AppDelegate.shared as? AppDelegate)?.imageDefaults {
+                imageDefaults.filterImageAndSave(with: imageId, pngData: imageData)
+            }
+        #endif
         
         super.goForward()
     }


### PR DESCRIPTION
Switched to not process edge detected filter image for validation app which was causing crashes in release on newer phones or newer xCode builds. See https://github.com/BradLarson/GPUImage2/issues/316 for more details.