### PR TITLE
PSR-358

### DIFF
--- a/Psorcast/PsorcastValidation/PsoriasisDrawCompletionStepViewController.swift
+++ b/Psorcast/PsorcastValidation/PsoriasisDrawCompletionStepViewController.swift
@@ -157,13 +157,13 @@ open class PsoriasisDrawCompletionStepViewController: RSDStepViewController, Pro
         self.navigationHeader?.textLabel?.textAlignment = .center
         
         let processor = PsorcastTaskResultProcessor.shared
+        processor.processingFinishedDelegate = self
         
         // If we have finished processing then show coverage, otherwise wait until delegate fires
         if !processor.isProcessing {
             self.refreshPsoriasisDrawCoverage()
             self.loadingSpinner.isHidden = true
         } else {
-            processor.processingFinishedDelegate = self
             self.navigationHeader?.titleLabel?.text = Localization.localizedString("CALCULATING_COVERAGE")
             self.navigationHeader?.textLabel?.text = ""
         }


### PR DESCRIPTION
Fixed bug where delegate was not always getting set, locking the user on the completion screen after hitting “done” button.

This actually ended up being a pretty simple bug where the processing finished delegate wasn’t always being set to the completion screen if you entered the screen without any background processes running.  It was happening more frequently on the archived production build because that build runs faster so when the user entered the completion screen, the background tasks had already completed. I found that 100% every time repro steps was to just select "I do not have psoriasis right now".