### PR TITLE
Profile updates

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		047C2CD425F16628006AA52B /* PopTip+Transitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047C2CCE25F16628006AA52B /* PopTip+Transitions.swift */; };
 		04F00572243FE64800EDB120 /* ShowInsightStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F00571243FE64800EDB120 /* ShowInsightStepViewController.swift */; };
 		04F00578243FE76E00EDB120 /* ShowInsightStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 04F00577243FE76E00EDB120 /* ShowInsightStepViewController.xib */; };
+		04F2653426839954004140B7 /* PrivacyPolicy.html in Resources */ = {isa = PBXBuildFile; fileRef = 04F2652F26839954004140B7 /* PrivacyPolicy.html */; };
 		CB03196523E3ED0A005063A3 /* ReviewCaptureStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB03196423E3ED09005063A3 /* ReviewCaptureStepViewController.swift */; };
 		CB03196723E40836005063A3 /* ReviewCaptureStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB03196623E40835005063A3 /* ReviewCaptureStepViewController.xib */; };
 		CB05146C237F27560058D746 /* DigitalJarOpen.json in Resources */ = {isa = PBXBuildFile; fileRef = CB05146B237F27560058D746 /* DigitalJarOpen.json */; };
@@ -387,6 +388,8 @@
 		047C2CCE25F16628006AA52B /* PopTip+Transitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PopTip+Transitions.swift"; sourceTree = "<group>"; };
 		04F00571243FE64800EDB120 /* ShowInsightStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowInsightStepViewController.swift; sourceTree = "<group>"; };
 		04F00577243FE76E00EDB120 /* ShowInsightStepViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShowInsightStepViewController.xib; sourceTree = "<group>"; };
+		04F2652F26839954004140B7 /* PrivacyPolicy.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = PrivacyPolicy.html; sourceTree = "<group>"; };
+		04F2653726839B5B004140B7 /* ConsentForm.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = ConsentForm.html; sourceTree = "<group>"; };
 		CB03196423E3ED09005063A3 /* ReviewCaptureStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReviewCaptureStepViewController.swift; sourceTree = "<group>"; };
 		CB03196623E40835005063A3 /* ReviewCaptureStepViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReviewCaptureStepViewController.xib; sourceTree = "<group>"; };
 		CB05146B237F27560058D746 /* DigitalJarOpen.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = DigitalJarOpen.json; sourceTree = "<group>"; };
@@ -977,7 +980,9 @@
 			isa = PBXGroup;
 			children = (
 				CBFF927F25E19B7300EC34DB /* CSS_files */,
+				04F2653726839B5B004140B7 /* ConsentForm.html */,
 				CBFF927D25E19B6200EC34DB /* PhoneLearnMore.html */,
+				04F2652F26839954004140B7 /* PrivacyPolicy.html */,
 			);
 			name = HTML;
 			sourceTree = "<group>";
@@ -1297,6 +1302,7 @@
 				CB7CF2482400CFAA003E02A5 /* WelcomeVideo.mov in Resources */,
 				CBDCDC8523F3848E00E5CEB8 /* ToesPhoto.mov in Resources */,
 				FFABCBCC22DD1EEC00D11109 /* LaunchScreen.storyboard in Resources */,
+				04F2653426839954004140B7 /* PrivacyPolicy.html in Resources */,
 				CB5A9400265EAB1A0063994F /* EnvironmentalStepViewController.xib in Resources */,
 				CBDCDC8023F3848500E5CEB8 /* PsoriasisAreaPhoto.json in Resources */,
 				CB9F5E2522E0BED3003FBCEF /* lato_regular.ttf in Resources */,

--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		04F00572243FE64800EDB120 /* ShowInsightStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F00571243FE64800EDB120 /* ShowInsightStepViewController.swift */; };
 		04F00578243FE76E00EDB120 /* ShowInsightStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 04F00577243FE76E00EDB120 /* ShowInsightStepViewController.xib */; };
 		04F2653426839954004140B7 /* PrivacyPolicy.html in Resources */ = {isa = PBXBuildFile; fileRef = 04F2652F26839954004140B7 /* PrivacyPolicy.html */; };
+		04F2654C26845794004140B7 /* ConsentForm.html in Resources */ = {isa = PBXBuildFile; fileRef = 04F2653726839B5B004140B7 /* ConsentForm.html */; };
 		CB03196523E3ED0A005063A3 /* ReviewCaptureStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB03196423E3ED09005063A3 /* ReviewCaptureStepViewController.swift */; };
 		CB03196723E40836005063A3 /* ReviewCaptureStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB03196623E40835005063A3 /* ReviewCaptureStepViewController.xib */; };
 		CB05146C237F27560058D746 /* DigitalJarOpen.json in Resources */ = {isa = PBXBuildFile; fileRef = CB05146B237F27560058D746 /* DigitalJarOpen.json */; };
@@ -1297,6 +1298,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				04F2654C26845794004140B7 /* ConsentForm.html in Resources */,
 				CBDCDC7B23F3848500E5CEB8 /* FootImaging.json in Resources */,
 				CB9F5E2222E0BED3003FBCEF /* lato_italic.ttf in Resources */,
 				CB7CF2482400CFAA003E02A5 /* WelcomeVideo.mov in Resources */,

--- a/Psorcast/Psorcast/ConsentForm.html
+++ b/Psorcast/Psorcast/ConsentForm.html
@@ -88,8 +88,8 @@ if (msoBrowserCheck())
  /* Style Definitions */
  p.MsoNormal, li.MsoNormal, div.MsoNormal
 	{margin:0in;
-	line-height:115%;
-	font-size:11.0pt;
+	line-height:150%;
+	font-size:30.0pt;
 	font-family:"Arial",sans-serif;}
 .MsoChpDefault
 	{font-family:"Arial",sans-serif;}

--- a/Psorcast/Psorcast/ConsentForm.html
+++ b/Psorcast/Psorcast/ConsentForm.html
@@ -1,0 +1,750 @@
+<html>
+
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=Generator content="Microsoft Word 15 (filtered)">
+
+<style id="dynCom" type="text/css"><!-- --></style>
+<script language="JavaScript"><!--
+function msoCommentShow(anchor_id, com_id)
+{
+	if(msoBrowserCheck()) 
+		{
+		c = document.all(com_id);
+		a = document.all(anchor_id);
+		if (null != c && null == c.length && null != a && null == a.length)
+			{
+			var cw = c.offsetWidth;
+			var ch = c.offsetHeight;
+			var aw = a.offsetWidth;
+			var ah = a.offsetHeight;
+			var x  = a.offsetLeft;
+			var y  = a.offsetTop;
+			var el = a;
+			while (el.tagName != "BODY") 
+				{
+				el = el.offsetParent;
+				x = x + el.offsetLeft;
+				y = y + el.offsetTop;
+				}
+			var bw = document.body.clientWidth;
+			var bh = document.body.clientHeight;
+			var bsl = document.body.scrollLeft;
+			var bst = document.body.scrollTop;
+			if (x + cw + ah / 2 > bw + bsl && x + aw - ah / 2 - cw >= bsl ) 
+				{ c.style.left = x + aw - ah / 2 - cw; }
+			else 
+				{ c.style.left = x + ah / 2; }
+			if (y + ch + ah / 2 > bh + bst && y + ah / 2 - ch >= bst ) 
+				{ c.style.top = y + ah / 2 - ch; }
+			else 
+				{ c.style.top = y + ah / 2; }
+			c.style.visibility = "visible";
+}	}	}
+function msoCommentHide(com_id) 
+{
+	if(msoBrowserCheck())
+		{
+		c = document.all(com_id);
+		if (null != c && null == c.length)
+		{
+		c.style.visibility = "hidden";
+		c.style.left = -1000;
+		c.style.top = -1000;
+		} } 
+}
+function msoBrowserCheck()
+{
+	ms = navigator.appVersion.indexOf("MSIE");
+	vers = navigator.appVersion.substring(ms + 5, ms + 6);
+	ie4 = (ms > 0) && (parseInt(vers) >= 4);
+	return ie4;
+}
+if (msoBrowserCheck())
+{
+	document.styleSheets.dynCom.addRule(".msocomanchor","background: infobackground");
+	document.styleSheets.dynCom.addRule(".msocomoff","display: none");
+	document.styleSheets.dynCom.addRule(".msocomtxt","visibility: hidden");
+	document.styleSheets.dynCom.addRule(".msocomtxt","position: absolute");
+	document.styleSheets.dynCom.addRule(".msocomtxt","top: -1000");
+	document.styleSheets.dynCom.addRule(".msocomtxt","left: -1000");
+	document.styleSheets.dynCom.addRule(".msocomtxt","width: 33%");
+	document.styleSheets.dynCom.addRule(".msocomtxt","background: infobackground");
+	document.styleSheets.dynCom.addRule(".msocomtxt","color: infotext");
+	document.styleSheets.dynCom.addRule(".msocomtxt","border-top: 1pt solid threedlightshadow");
+	document.styleSheets.dynCom.addRule(".msocomtxt","border-right: 2pt solid threedshadow");
+	document.styleSheets.dynCom.addRule(".msocomtxt","border-bottom: 2pt solid threedshadow");
+	document.styleSheets.dynCom.addRule(".msocomtxt","border-left: 1pt solid threedlightshadow");
+	document.styleSheets.dynCom.addRule(".msocomtxt","padding: 3pt 3pt 3pt 3pt");
+	document.styleSheets.dynCom.addRule(".msocomtxt","z-index: 100");
+}
+// --></script>
+<style>
+<!--
+ /* Font Definitions */
+ @font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+ /* Style Definitions */
+ p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0in;
+	line-height:115%;
+	font-size:11.0pt;
+	font-family:"Arial",sans-serif;}
+.MsoChpDefault
+	{font-family:"Arial",sans-serif;}
+.MsoPapDefault
+	{line-height:115%;}
+ /* Page Definitions */
+ @page WordSection1
+	{size:8.5in 11.0in;
+	margin:.5in .5in .5in .5in;}
+div.WordSection1
+	{page:WordSection1;}
+ /* List Definitions */
+ ol
+	{margin-bottom:0in;}
+ul
+	{margin-bottom:0in;}
+-->
+</style>
+
+</head>
+
+<body lang=EN-US style='word-wrap:break-word'>
+
+<div class=WordSection1>
+
+<p class=MsoNormal align=center style='text-align:center'><b><span lang=EN
+style='font-family:"Times New Roman",serif'>RESEARCH STUDY INFORMATION AND
+CONSENT FORM </span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>Title:                                       Psorcast
+Study</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>Principal
+Investigator:            </span></b><span lang=EN style='font-family:"Times New Roman",serif'>Lara
+Mangravite, PhD</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>Contact
+address:                     </span></b><span lang=EN style='font-family:"Times New Roman",serif'>2901
+3rd Avenue Seattle, WA 98121</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>Contact
+Phone Number:         </span></b><span lang=EN style='font-family:"Times New Roman",serif'>[study
+phone number]</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>Email
+Address:</span></b><span lang=EN style='font-family:"Times New Roman",serif'>                       </span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>Sponsor: 
+                                </span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>OVERVIEW</span></b></p>
+
+<p class=MsoNormal style='line-height:normal'><b><span lang=EN
+style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>You are invited to participate in the Psorcast
+research study. The purpose of this study is to look for patterns over time. If
+you join the study, we will ask you to complete study activities on the study
+mobile app on a weekly or monthly basis. We would like you to participate for X
+years, but you can participate as long as you like. You may not directly
+benefit from taking part but you may help researchers better understand
+variations in symptoms of psoriasis disease. We expect the risks of participating
+in this research to be low. Seeing trends in your data may be interesting to
+you.  It may also cause a range of emotions. </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>The Psorcast research study was developed by Sage
+Bionetworks (a not-for-profit research organization). The Principal Investigator
+for this study is Lara Mangravite, Ph.D. If you have any questions about this
+study please contact the Study Team at &lt;study phone number&gt; (toll-free)
+or email at &lt;email address&gt;. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>WHAT
+IS INVOLVED</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>We will ask you to download the free study app to your
+phone. In the app, we will ask you questions about your health and your medical
+history. We will also ask you to complete the simple activities described
+below. These questions and activities are important for the research study.</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>We will ask you to do:</span></p>
+
+<p class=MsoNormal style='margin-left:0in;text-indent:0in;line-height:normal'><span
+lang=EN style='color:black'><span style='font:7.0pt "Times New Roman"'> </span>•<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><b><span lang=EN style='font-family:"Times New Roman",serif'>Health
+survey</span></b><span lang=EN style='font-family:"Times New Roman",serif'>:
+Answer a few questions one time (5-minutes) </span></p>
+
+<p class=MsoNormal style='margin-left:0in;text-indent:0in;line-height:normal'><span
+lang=EN style='color:black'><span style='font:7.0pt "Times New Roman"'> </span>•<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><b><span lang=EN style='font-family:"Times New Roman",serif'>Activities</span></b><span
+lang=EN style='font-family:"Times New Roman",serif'>: (10-minutes): Please note
+that activities are voluntary.</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>Track
+your symptoms, triggers and medications. </span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>Psoriasis
+Draw</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>Psoriasis
+Area Photo</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>Digital
+Jar Open</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>Fingers
+Photo</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>Toes
+Photo </span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>30
+Second Walk</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>Joint
+Count</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-1.0in;line-height:
+normal'><span lang=EN style='font-size:14.0pt;color:black'><span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span>○<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>Demographics
+</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;line-height:normal'><span lang=EN
+style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>Some study activities need your phone’s sensors to be
+turned on. For example we use the phone’s GPS to calculate how far you travel
+while completing the walking activity.  We do not use the GPS to find out your
+exact location. In addition to collecting data while you use the study app, we
+will ask you whether we can collect data passively each time your phone sensors
+are activated outside of the study app. This is to see if the measurements are
+different when you are doing the Psorcast app activities or doing normal daily
+activities. During passive data collection, the sensors will only be collecting
+data on your movement and on your finger tapping. We will not know your exact
+location or what you are typing on your phone. You can participate in the
+Psorcast study even if you do not agree to the passive data collection. You can
+enable or disable this passive data collection function in the Psorcast app at
+any time.</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>DATA
+COLLECTION, STORAGE, AND PRIVACY</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>Your
+privacy is important to us. We will make every effort to protect your privacy.
+We will process your data electronically. By consenting to this study, you
+acknowledge that your data will be transferred to the United States. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>The data we collect through the app is encrypted on
+the phone. This means your data is protected. Unauthorized people cannot easily
+understand your data when it is encrypted.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>We will separate the account information that
+identifies you from your study data. Your account information will not be
+stored with your survey responses or app measurements.</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>Instead of using your name or information that
+directly identifies you, we will create a Global Unique Identifier (GUID) for
+you. This code cannot be used to directly identify you. We will use your GUID
+instead of your name alongside your data. Only key people from our study team
+can link your identity to your study data. </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>We
+will combine your coded study data with the coded study data of other
+volunteers.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>We
+will transfer this combined coded study data on the cloud-based Synapse data
+analysis platform. &nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>WE WILL NEVER SELL, RENT, OR LEASE YOUR CONTACT
+INFORMATION. Please read our </span><span lang=EN><a></a></span><span lang=EN
+style='font-family:"Times New Roman",serif'>Privacy Policy</span><span lang=EN><a
+class=msocomanchor id="_anchor_1"
+onmouseover="msoCommentShow('_anchor_1','_com_1')"
+onmouseout="msoCommentHide('_com_1')" href="#_msocom_1" language=JavaScript
+name="_msoanchor_1">[1]</a>&nbsp;</span><span lang=EN style='font-family:"Times New Roman",serif'>
+for more information.</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>DATA
+USE &amp; TRENDS</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>This is your data. You’ll be able to view your
+symptoms, triggers, medication adherence (if you track them), your activities,
+and data trends on the app. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>We
+will analyze the combined coded study data. We will look for patterns. These
+patterns may help us better understand the symptoms of Psoriasis.  Also, we
+will investigate how mobile phones and sensors perform in this type of
+research. Our goal is to improve the quality of life for people with psoriasis.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>We will not use the coded study data for commercial
+advertising.</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>SHARING
+FOR FUTURE RESEARCH</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>The
+same coded study data that you donate for Psorcast study could be used for
+other research. You get to decide if you want to share your coded study data
+with qualified researchers worldwide. If you give permission, sharing will be
+done without additional informed consent.</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>We have rules to qualify researchers. Qualified
+researchers must register on Synapse, our data analysis platform. To access the
+data, qualified researchers must write a short statement about their research.
+The research could be about any topic. The research could be on topics you
+disagree with or find offensive.  We post the researchers’ statements on
+Synapse for anyone to read. They must sign an oath to use the data ethically
+and do no harm. Researchers will not be able to easily figure out your identity
+using your coded study data. </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>Anyone in the US or abroad can qualify to be a
+qualified researcher. The person could be from a non-profit institution,
+company, or private citizen. </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>You cannot take back your data once it is used in
+research. Your data will not be destroyed or deleted.  Once we share your data,
+there isn’t a way for us to delete it or take it back.</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>POTENTIAL
+RISKS</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>This
+is not a medical treatment study. We do not expect medical side effects from
+participating in this study. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>We
+take great care to protect your information. However, if there is a data breach
+it may be possible to identify you. This risk is low but it is not zero.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>Some
+of the activities and questions we ask could be tiring, frustrating, boring or
+may make you feel uncomfortable. Seeing your data may generate a wide range of
+emotions. It could affect your mood. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>Be
+aware that other people may glimpse the study notifications and/or reminders on
+your phone and realize you are enrolled in this study. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>Participation
+in this study may involve risks that are not known at this time. You will be
+told of any new information that might change your decision to be in this
+study.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>POTENTIAL
+BENEFITS</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>You
+may or may not benefit from volunteering for this research study. The primary
+benefit of this study is increasing understanding of the symptoms of Psoriasis.
+We will be looking for health patterns across large groups, not individual
+health trends. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>You
+will be able to view and download your study data. You can share your data with
+anyone you choose. </span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>NOT
+MEDICAL CARE</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>Psorcast
+is a research study. The Psorcast app is not a diagnostic tool. It shouldn’t be
+used for medical care, diagnosis, or treatment. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>The
+sensor data collected through the app are not yet validated as measurements of
+Psoriasis symptoms. We are analyzing this data to see how accurate and reliable
+it is. For diagnosis or treatment consult with a medical professional.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>If
+you have questions or concerns related to your health, you should see a
+healthcare provider. You should not use Psorcast in place of seeing a
+healthcare provider.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>ISSUES
+TO CONSIDER</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>Transmitting
+data collected in this study may count against your mobile data plan. You may
+configure the application to only use Wi-Fi connections to limit the impact
+this data collection has on your data plan. </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>Research may lead to patentable discoveries or
+commercial product(s). You will not profit from future research and
+discoveries. For example, you will not be paid for being in the study and/or
+sharing your data. </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>The
+risk of being injured while participating is low. We will not pay for medical
+care or compensate you if you think you were injured as a result of taking part
+in the study. You will be responsible for the cost of your medical care. <br>
+<br>
+</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>LEAVING
+THE STUDY</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>You may leave the study at any time for any reason.
+The study will last X years.  We hope that you can participate for X years, but
+it is up to you.  You can participate for as long as you like. &nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>If you leave the study, you withdraw your consent. You
+will be logged out of your account and no more data will be collected. If you
+wish to re-enroll at a later date you will be asked for your informed consent
+again.</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>Your coded study data from before your withdrawal will
+continue to be used in the study. It will not be destroyed or deleted.   </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>The study team may also withdraw you from the study at
+any time for any reason.</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>There are two ways to ask questions or to leave the
+study. You can do so directly from your app profile page. Or you can contact
+us: &lt;study phone number&gt; or email at &lt;study email address&gt;. You can
+also uninstall the app from your phone at any time. &nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:120%'><span lang=EN style='font-family:
+"Times New Roman",serif;background:white'>&nbsp;</span></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>CONTACTS</span></b></p>
+
+<p class=MsoNormal><b><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></b></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>We
+may reach out to you. We might want to alert you to research events, like
+webinars. We might want to tell you about other research opportunities. </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>You
+can still participate in Psorcast even if you opt out of these follow-up
+notifications.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'> </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>There
+are two ways to opt out of notifications. You can adjust the “permissions”
+setting in your Psorcast profile. </span></p>
+
+<p class=MsoNormal style='margin-top:14.05pt;margin-right:84.95pt;margin-bottom:
+0in;margin-left:1.65pt;margin-bottom:.0001pt;text-indent:-.05pt;line-height:
+97%'><span lang=EN style='font-family:"Times New Roman",serif'>If you have
+questions about your rights as a research subject or if you have questions,
+concerns or complaints about the research, you may contact: </span></p>
+
+<p class=MsoNormal style='margin-top:13.7pt;margin-right:0in;margin-bottom:
+0in;margin-left:37.4pt;margin-bottom:.0001pt;line-height:normal'><span lang=EN
+style='font-family:"Times New Roman",serif'>Western Institutional Review Board<sup>®</sup>(WIRB<sup>®</sup>)
+</span></p>
+
+<p class=MsoNormal style='margin-top:.65pt;margin-right:0in;margin-bottom:0in;
+margin-left:37.7pt;margin-bottom:.0001pt;line-height:normal'><span lang=EN
+style='font-family:"Times New Roman",serif'>3535 Seventh Avenue, SW </span></p>
+
+<p class=MsoNormal style='margin-top:.65pt;margin-right:0in;margin-bottom:0in;
+margin-left:37.65pt;margin-bottom:.0001pt;line-height:normal'><span lang=EN
+style='font-family:"Times New Roman",serif'>Olympia, Washington 98502 </span></p>
+
+<p class=MsoNormal style='margin-top:.65pt;margin-right:0in;margin-bottom:0in;
+margin-left:37.6pt;margin-bottom:.0001pt;line-height:normal'><span lang=EN
+style='font-family:"Times New Roman",serif'>Telephone: 1-800-562-4789 or
+360-252-2500 </span></p>
+
+<p class=MsoNormal style='margin-top:.65pt;margin-right:0in;margin-bottom:0in;
+margin-left:37.5pt;margin-bottom:.0001pt;line-height:normal'><span lang=EN
+style='font-family:"Times New Roman",serif'>E-mail: Help@wirb.com. </span></p>
+
+<p class=MsoNormal style='margin-top:14.25pt;margin-right:47.75pt;margin-bottom:
+0in;margin-left:1.3pt;margin-bottom:.0001pt;text-indent:.05pt;line-height:101%'><span
+lang=EN style='font-family:"Times New Roman",serif'>WIRB is a group of people
+who independently review research. WIRB will not be able to answer some
+research-specific questions. However, you may contact WIRB if the hackathon
+administrators cannot be reached or if you wish to talk to someone other than
+the research staff.  </span></p>
+
+<p class=MsoNormal style='margin-top:14.25pt;margin-right:47.75pt;margin-bottom:
+0in;margin-left:1.3pt;margin-bottom:.0001pt;text-indent:.05pt;line-height:101%'><span
+lang=EN style='font-family:"Times New Roman",serif'>Do not sign this consent
+form unless you have had a chance to ask questions and have gotten satisfactory
+answers. </span></p>
+
+<p class=MsoNormal style='margin-top:.2in;margin-right:67.35pt;margin-bottom:
+0in;margin-left:1.3pt;margin-bottom:.0001pt;text-indent:.2pt;line-height:102%'><span
+lang=EN style='font-family:"Times New Roman",serif'>If you agree to be in this
+study, you will receive a signed and dated copy of this consent form for your
+records. </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>If required by law, we may give your contact
+information and identifiable study data to:</span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>Insert relevant authorities here: </span></p>
+
+<p class=MsoNormal style='line-height:normal'><span lang=EN style='font-family:
+"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in;line-height:normal'><span
+lang=EN style='font-family:"Times New Roman",serif'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>The US
+Department of Health and Human Services (HHS), the Office for Human Research
+Protection (OHRP), the Food and Drug Administration (FDA), and other agencies
+for review of our research procedures.</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in;line-height:normal'><span
+lang=EN style='font-family:"Times New Roman",serif'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span><span lang=EN style='font-family:"Times New Roman",serif'>The
+Institutional Review Board (IRB) so they can monitor the safety, effectiveness,
+and conduct of our research </span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal style='margin-top:14.6pt;margin-right:0in;margin-bottom:
+0in;margin-left:1.7pt;margin-bottom:.0001pt;line-height:normal'><b><span
+lang=EN style='font-family:"Times New Roman",serif'>CONSENT </span></b></p>
+
+<p class=MsoNormal style='margin-top:.7pt;margin-right:63.8pt;margin-bottom:
+0in;margin-left:1.55pt;margin-bottom:.0001pt;line-height:102%'><span lang=EN
+style='font-family:"Times New Roman",serif'>I have read this consent form (or
+it has been read to me). All my questions about the study and my part in it
+have been answered. I freely consent to be in this research study. </span></p>
+
+<p class=MsoNormal style='margin-top:13.9pt;margin-right:59.3pt;margin-bottom:
+0in;margin-left:1.8pt;margin-bottom:.0001pt;text-indent:-.25pt;line-height:
+102%'><span lang=EN style='font-family:"Times New Roman",serif'>I authorize the
+use and disclosure of my health information to the parties listed in the
+consent form. By signing this consent form, I have not given up any of my legal
+rights.</span></p>
+
+<p class=MsoNormal style='margin-top:13.9pt;margin-right:59.3pt;margin-bottom:
+0in;margin-left:1.8pt;margin-bottom:.0001pt;text-indent:-.25pt;line-height:
+102%'><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>Thank
+you for considering participating in the Psorcast study.</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>Psorcast
+Study Team</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&lt;study
+email address&gt;</span></p>
+
+<p class=MsoNormal><span lang=EN style='font-family:"Times New Roman",serif'>&lt;study
+phone number&gt;</span></p>
+
+</div>
+
+<div>
+
+<hr class=msocomoff align=left size=1 width="33%">
+
+<div>
+
+<div id="_com_1" class=msocomtxt language=JavaScript
+onmouseover="msoCommentShow('_anchor_1','_com_1')"
+onmouseout="msoCommentHide('_com_1')"><a name="_msocom_1"></a>
+
+<p class=MsoNormal style='line-height:normal;border:none'><span lang=EN
+style='color:black'>link</span></p>
+
+</div>
+
+</div>
+
+</div>
+
+</body>
+
+</html>

--- a/Psorcast/Psorcast/PrivacyPolicy.html
+++ b/Psorcast/Psorcast/PrivacyPolicy.html
@@ -1,0 +1,519 @@
+<html>
+
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=Generator content="Microsoft Word 15 (filtered)">
+<style>
+<!--
+ /* Font Definitions */
+ @font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Lato;}
+ /* Style Definitions */
+ p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0in;
+	line-height:150%;
+	font-size:12.0pt;
+	font-family:Lato;}
+h1
+	{margin-top:20.0pt;
+	margin-right:0in;
+	margin-bottom:6.0pt;
+	margin-left:0in;
+	line-height:150%;
+	page-break-after:avoid;
+	font-size:20.0pt;
+	font-family:Lato;
+	font-weight:normal;}
+h2
+	{margin-top:.25in;
+	margin-right:0in;
+	margin-bottom:6.0pt;
+	margin-left:0in;
+	line-height:150%;
+	page-break-after:avoid;
+	font-size:16.0pt;
+	font-family:Lato;
+	font-weight:normal;}
+h3
+	{margin-top:16.0pt;
+	margin-right:0in;
+	margin-bottom:4.0pt;
+	margin-left:1.0in;
+	line-height:150%;
+	page-break-after:avoid;
+	font-size:14.0pt;
+	font-family:Lato;
+	color:#434343;
+	font-weight:normal;}
+h4
+	{margin-top:14.0pt;
+	margin-right:0in;
+	margin-bottom:4.0pt;
+	margin-left:0in;
+	line-height:150%;
+	page-break-after:avoid;
+	font-size:12.0pt;
+	font-family:Lato;
+	color:#666666;
+	font-weight:normal;}
+.MsoChpDefault
+	{font-size:12.0pt;
+	font-family:Lato;}
+.MsoPapDefault
+	{line-height:150%;}
+ /* Page Definitions */
+ @page WordSection1
+	{size:8.5in 11.0in;
+	margin:1.0in 1.0in 1.0in 1.0in;}
+div.WordSection1
+	{page:WordSection1;}
+ /* List Definitions */
+ ol
+	{margin-bottom:0in;}
+ul
+	{margin-bottom:0in;}
+-->
+</style>
+
+</head>
+
+<body lang=EN-US style='word-wrap:break-word'>
+
+<div class=WordSection1>
+
+<h3 style='margin-left:0in'><a name="_heading=h.gjdgxs"></a><span lang=EN>Appendix
+C: Website Privacy Policy</span></h3>
+
+<h1><a name="_heading=h.30j0zll"></a><span lang=EN>Summary of Our Privacy
+Policy</span></h1>
+
+<p class=MsoNormal><span lang=EN>Sage Bionetworks (“Sage Bionetworks, “we,” or
+“us”) is a 501(c)(3) nonprofit biomedical research organization in the United
+States, created to enhance how researchers approach the complexity of human
+biological information and the treatment of disease. We have developed a mobile
+application (the “Psorcast App”) to gain insights into the variability of
+psoriatic disease symptom burden as measured by active task measurements and
+self-reported health information using a mobile app based research platform. The
+goal of the Psorcast research study (the “Study”) is to map the landscape of
+psoriatic disease symptoms and quality of life over time in real-world
+settings. </span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>Psorcast  is committed to protecting the
+privacy of the users of the website. This privacy policy tells what we will do
+with the information we collect from you through the website.</span></p>
+
+<h2><a name="_heading=h.1fob9te"></a><span lang=EN>Data We Collect From You</span></h2>
+
+<h3 style='margin-left:0in'><a name="_heading=h.3znysh7"></a><span lang=EN>Who
+You Are (User Information)</span></h3>
+
+<p class=MsoNormal><span lang=EN>Information collected during the informed
+consent and account creation process, and any correspondence, you have with us.
+For example, this could be your name, email and any other contact information
+you shared with us.<br>
+<br>
+</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.2et92p0"></a><span lang=EN>Where
+you go on the Website (Usage Data)</span></h3>
+
+<p class=MsoNormal><span lang=EN>Technical data on the different pages you
+visit on the study website. For example, we may collect the date and time when
+you visit the study's homepage.</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<h2><a name="_heading=h.tyjcwt"></a><span lang=EN>Why We Collect This Data</span></h2>
+
+<p class=MsoNormal><span lang=EN>We collect this data to maintain and improve
+the website, and to be able to correspond with you. We also collect this data
+to adhere to state and federal laws and prevent and deal with cases of abuse or
+fraud.</span></p>
+
+<h2><a name="_heading=h.3dy6vkm"></a><span lang=EN>How We Process Information</span></h2>
+
+<p class=MsoNormal><span lang=EN>We process the information we collect through
+the Psorcast app. Here are the steps we will take to process your information:</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>We will separate your account information like
+your name and email address from your study data like your answers to the
+surveys. We will assign you a random study code. We will add this code to your
+study data. The key that links this code to your name is kept in a separate,
+secure location.</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>We will combine your coded study data (without
+your name) with the coded study data from other people in Psorcast. We will use
+this combined data for our research.</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>We will store Psorcast research data we
+collect on Synapse. Synapse is a cloud-based research platform. Researchers
+from the sponsor, the study team and researchers’ partners will access and
+analyze data. We may report the results of our research through blogs or
+scientific publications. Your name will not appear in the results we report.</span></p>
+
+<h2><a name="_heading=h.1t3h5sf"></a><span lang=EN>To Whom/When We Disclose
+Data</span></h2>
+
+<p class=MsoNormal><span lang=EN>We use the services of third-party vendors. 
+We mandate that all service providers put measures in place to protect and
+secure your data. They are not allowed to use or share your personal
+information outside the scope of their work on the website. We may be required
+to share your personal information for legal purposes.  </span></p>
+
+<h2><a name="_heading=h.4d34og8"></a><span lang=EN>How Long We Keep This Data</span></h2>
+
+<h3 style='margin-left:0in'><a name="_heading=h.2s8eyo1"></a><span lang=EN>User
+Information</span></h3>
+
+<p class=MsoNormal><span lang=EN>Information retained for as long as the user’s
+account is active. Users may edit their information or remove their information
+by withdrawing from the study in the profile settings.</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.17dp8vu"></a><span lang=EN>Usage
+and Activity Data</span></h3>
+
+<p class=MsoNormal><span lang=EN>Data will be retained and archived
+indefinitely for auditing and compliance purposes. </span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.3rdcrjn"></a><span lang=EN>Cross-Border
+Transfer of Data</span></h3>
+
+<p class=MsoNormal><span lang=EN>The Synapse platform and the study data may be
+accessed by users outside the United States. </span></p>
+
+<h2><a name="_heading=h.26in1rg"></a><span lang=EN>What We Do Not Do</span></h2>
+
+<p class=MsoNormal><span lang=EN>We do not use your personal information for
+advertising purposes. We do not sell or lease your information.</span></p>
+
+<h2><a name="_heading=h.lnxbz9"></a><span lang=EN>Your Rights and Choices</span></h2>
+
+<p class=MsoNormal><span lang=EN>You may access, update, correct or deactivate
+your account. To comply with our contractual obligations, your usage and
+activity data are parts of our permanent records. </span></p>
+
+<h2><a name="_heading=h.35nkun2"></a><span lang=EN>How to Contact Us</span></h2>
+
+<p class=MsoNormal><span lang=EN>You can contact our Data Protection Officer
+(DPO) at <a href="mailto:privacyofficer@sagebionetworks.org"><span
+style='color:#4A86E8'>privacyofficer@sagebionetworks.org</span></a><a
+href="mailto:privacyofficer@sagebionetworks.org"><span style='color:windowtext'>.</span></a></span></p>
+
+<h4><a name="_heading=h.1ksv4uv"></a><i><span lang=EN style='font-size:10.0pt;
+line-height:150%;color:black'>This is a summary of the Psorcast study privacy
+policy. Please read further for more detailed information.</span></i></h4>
+
+<h1><a name="_heading=h.2jxsxqh"></a><span lang=EN>Privacy Policy</span></h1>
+
+<p class=MsoNormal style='margin-bottom:4.0pt'><span lang=EN>Version: version
+1, 4.16.2021</span></p>
+
+<p class=MsoNormal><span lang=EN>Sage Bionetworks (“Sage Bionetworks, “we,” or
+“us”) is a 501(c)(3) nonprofit biomedical research organization in the United
+States, created to enhance how researchers approach the complexity of human
+biological information and the treatment of disease. We have developed a mobile
+application (the “Psorcast App”) to gain insights into the variability of
+psoriatic disease symptom burden as measured by active task measurements and
+self-reported health information using a mobile app based research platform. The
+goal of the Psorcast research study (the “Study”) is to map the landscape of
+psoriatic disease symptoms and quality of life over time in real-world
+settings. </span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>Psorcast  is committed to protecting the
+privacy of the users of the website. This privacy policy tells what we will do
+with the information we collect from you through the website.</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>This privacy policy explains how we protect
+personal information (“personal data”) received, used and disclosed by users.
+Personal information or personal data” means any direct information about you
+such as your name and contact information or indirect information that could be
+reasonably linked to you.</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>Please read this Privacy Policy carefully. By
+using the study website, you agree to this Privacy Policy. </span></p>
+
+<h2><a name="_heading=h.z337ya"></a><u><span lang=EN>Information We Collect</span></u></h2>
+
+<p class=MsoNormal><span lang=EN>When you use the website, you may provide to
+us and/or we may collect personal information about you and your activity on
+the website. “Personal information or personal data” means any direct
+information about you such as your name and contact information or indirect
+information that could be reasonably linked to you such as your device’s
+internet protocol address (IP Address).</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>We collect information about you in the
+following ways:</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.3j2qqm3"></a><span lang=EN
+style='color:black'>User Information</span></h3>
+
+<p class=MsoNormal><span lang=EN>We collect the following personal information during
+the account creation process:<br>
+<br>
+</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Your name</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Your email or mobile phone number</span></p>
+
+<p class=MsoNormal style='margin-left:1.0in'><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>We also collect information when you
+update/change your account and when you contact us. If you send us an email or
+otherwise communicate with us, we may keep a copy of that communication.</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.1y810tw"></a><span lang=EN
+style='color:black'>Usage Data</span></h3>
+
+<p class=MsoNormal><span lang=EN>Like most websites, we collect technical
+information on website usage. We may use cookies and similar technologies to
+record information such as but not limited to: date, time, pages and tools you
+used, your browser/client type, IP addresses, how you navigate the website, how
+you have found the website on the internet, and other service usage patterns.</span></p>
+
+<h2><a name="_heading=h.4i7ojhp"></a><u><span lang=EN>How We Use the
+Information We Collect</span></u></h2>
+
+<p class=MsoNormal><span lang=EN>We will use your personal information only as
+we describe here.</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.2xcytpi"></a><span lang=EN
+style='color:black'>User Information</span></h3>
+
+<p class=MsoNormal><span lang=EN>We use user-reported information for any of
+the following:</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Authenticating/administering your account </span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Responding to user requests, questions, and concerns </span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Requesting user feedback to enhance and improve the website</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Sending study communications such as newsletters and other materials
+that may be of interest to you.</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.1ci93xb"></a><span lang=EN
+style='color:black'>Usage Data</span></h3>
+
+<p class=MsoNormal><span lang=EN>We use usage data for the following purposes:</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Maintaining, securing, and enhancing the website</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Detecting and remedying disruptions in our systems</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Performing statistical analysis of usage patterns</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Operating, maintaining, enhancing, and providing all the features of
+the website</span></p>
+
+<h2 style='margin-top:14.0pt;page-break-after:auto'><a name="_heading=h.3whwml4"></a><u><span
+lang=EN>How We Disclose Information</span></u></h2>
+
+<h3 style='margin-top:14.0pt;margin-right:0in;margin-bottom:4.0pt;margin-left:
+0in;page-break-after:auto'><a name="_heading=h.2bn6wsx"></a><span lang=EN
+style='font-size:12.0pt;line-height:150%;color:black'>We do not sell, lease or
+otherwise disclose the information we collect about you, except as described
+here. We share user’s information in the following ways:</span></h3>
+
+<h3 style='margin-left:0in'><a name="_heading=h.qsh70q"></a><span lang=EN
+style='color:black'>Service Providers</span></h3>
+
+<p class=MsoNormal><span lang=EN>We may rely on third-party service providers
+to provide the necessary hardware, software, networking, storage, and related
+technology required to operate, support and maintain the website. We required
+that all service providers agree to put in place reasonable security to keep
+users information confidential and secure, and to process information only for
+performing tasks on Sage Bionetwork’s behalf. We do not permit service
+providers to use or disclose users’ information, except as necessary to their
+work on the website.</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.3as4poj"></a><span lang=EN
+style='color:black'>The Psorcast website uses the following third-party service
+providers:</span></h3>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Amazon Web Services</span></p>
+
+<p class=MsoNormal style='margin-left:.5in;text-indent:-.25in'><span lang=EN>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span><span
+lang=EN>Google Analytics</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.1pxezwc"></a><span lang=EN
+style='color:black'>Statistical and Aggregate Information</span></h3>
+
+<p class=MsoNormal><span lang=EN>In accordance with applicable law, we may
+share aggregate and statistical information derived from users’ information
+with third parties for analysis.</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.49x2ik5"></a><span lang=EN
+style='color:black'>Compliance with Laws</span></h3>
+
+<p class=MsoNormal><span lang=EN>We may be required by law to give your user
+information in the case of any civil, criminal, administrative, legislative, or
+other proceedings. We will protect your privacy as much as possible.</span></p>
+
+<h3 style='margin-left:0in'><a name="_heading=h.2p2csry"></a><span lang=EN
+style='color:black'>Business Transfers</span></h3>
+
+<p class=MsoNormal><span lang=EN>If Sage Bionetworks (website’s host) goes through
+a management or business transition such as a merger, closure, sale, joint
+venture, assignment, transfer, management reorganization, or other disposition
+of all or any portion of Sage Bionetworks’ business, assets, or stock,
+information or data may be transferred to a third party. In such cases, we will
+take reasonable steps to direct the transferee to use the information and data
+in a manner consistent with this Privacy Policy.</span></p>
+
+<h2><a name="_heading=h.147n2zr"></a><u><span lang=EN>Your Rights </span></u></h2>
+
+<p class=MsoNormal><span lang=EN>You may request to <b>access, update, correct,
+restrict or delete</b> the personal information you provide to us. You also
+have the right to object to the processing of your personal information under
+certain conditions. For all such inquiries, we can be reached at the following:</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal style='margin-left:.5in'><span lang=EN>Sage Bionetworks </span></p>
+
+<p class=MsoNormal style='margin-left:.5in'><span lang=EN>2901 Third Avenue,</span></p>
+
+<p class=MsoNormal style='margin-left:.5in'><span lang=EN>Suite 330</span></p>
+
+<p class=MsoNormal style='margin-left:.5in'><span lang=EN>Seattle, WA 98121</span></p>
+
+<p class=MsoNormal style='margin-left:.5in'><span lang=EN>United States of
+America</span></p>
+
+<p class=MsoNormal style='margin-left:.5in'><span lang=EN><a
+href="mailto:privacyofficer@sagebionetworks.org"><span style='color:#4A86E8'>privacyofficer@sagebionetworks.org</span></a></span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>Upon request, we will provide you with
+reasonable access to the personal information about you that we hold. If your
+personal account information is deleted, your account becomes deactivated.</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+<p class=MsoNormal><span lang=EN>You may <b>opt-out of receiving study
+communications</b> from us by clicking on the “unsubscribe” link included in
+each such communication or by notifying us by email at <u><span
+style='color:#4A86E8'>privacypolicy@sagebionetworks.org</span></u>  with the
+word “remove” in the subject header, and we will remove your contact details
+from our mailing list.</span></p>
+
+<h2 style='margin-top:14.0pt;page-break-after:auto'><a name="_heading=h.3o7alnk"></a><u><span
+lang=EN>Information/Data Security</span></u></h2>
+
+<p class=MsoNormal><span lang=EN>Sage Bionetworks maintains industry standard
+physical, organizational, technical, and administrative measures to protect the
+personal identifiable information we collect, store, or otherwise process in
+connection to the study against accidental, unlawful, or unauthorized access,
+destruction, disclosure, misuse, alteration, or loss. The data security measures
+are a combination of Privacy-Enhancing Technologies (PET) options and
+policies/processes for data handling. Still, no environment is 100% secure.
+There is some risk that an unauthorized third party may find a way to
+circumvent our security systems. </span></p>
+
+<p class=MsoNormal><span lang=EN><br>
+<u>User Information Retention</u></span></p>
+
+<p class=MsoNormal><span lang=EN>We keep the information, including personal
+information, for as long as necessary to provide our services and to fulfill
+any other purposes for which the information was initially collected, unless
+otherwise required by applicable law. For instance, we will keep personally
+identifiable information related to authentication of user identity only for as
+long as is necessary for authentication. Users may edit their information or
+remove their information by withdrawing from the study in the profile settings.
+We will retain and archive a record of user’s activities performed while the
+account was active to use for audit purposes, legitimate business purposes, to
+keep with our legal obligations, resolve disputes, and enforce our agreements
+and policies.</span></p>
+
+<h2 style='margin-top:14.0pt;page-break-after:auto'><a name="_heading=h.23ckvvd"></a><u><span
+lang=EN>Cross-Border Transfer of Your Information</span></u></h2>
+
+<p class=MsoNormal><span lang=EN>Although you may access the website from a
+location outside of the United States, the website is primarily operated and
+managed within the United States. When we transfer information and data, we
+will protect the information and data as described in this Privacy Policy.</span></p>
+
+<h2 style='margin-top:14.0pt;page-break-after:auto'><a name="_heading=h.ihv636"></a><u><span
+lang=EN>Changes to Our Privacy Policy</span></u></h2>
+
+<p class=MsoNormal><span lang=EN>We may change this privacy policy from time to
+time. Any changes will be posted on this page with an updated revision date. In
+the event that any changes to this privacy policy materially alter your rights
+or obligations under this privacy policy, we will make reasonable efforts to
+notify you. </span></p>
+
+<h2><a name="_heading=h.32hioqz"></a><u><span lang=EN>Contact</span></u></h2>
+
+<p class=MsoNormal><span lang=EN>Sage Bionetworks is the controller of your
+information when it is collected and processed in the context of our sites and
+services. Our Data Protection Officer (DPO) is responsible for overseeing what
+we do with your information and ensuring we comply with applicable data
+protection laws. Our Data Protection Officer may be contacted by emailing <a
+href="mailto:privacypolicy@sagebionetworks.org"><span style='color:#4A86E8'>privacyofficer@sagebionetworks.or</span></a><span
+style='color:#4A86E8'>g</span> or by writing to Sage Bionetworks, Attention:
+Data Protection Officer, 2901 Third Avenue, Suite 330, Seattle, WA 98121,
+United States of America.</span></p>
+
+<h2><a name="_heading=h.1hmsyys"></a><u><span lang=EN>Updates</span></u></h2>
+
+<p class=MsoNormal><span lang=EN>We may update our Privacy Policy from time to
+time to clarify how we collect, process, store, use and disclose information. We
+want to be as transparent as possible about the changes we make to our Privacy
+Policy.</span></p>
+
+<h2><a name="_heading=h.41mghml"></a><u><span lang=EN>Versions</span></u></h2>
+
+<p class=MsoNormal style='margin-bottom:4.0pt'><span lang=EN>Version: version
+1, 4.16.2021</span></p>
+
+<p class=MsoNormal><span lang=EN>&nbsp;</span></p>
+
+</div>
+
+</body>
+
+</html>

--- a/Psorcast/Psorcast/PrivacyPolicy.html
+++ b/Psorcast/Psorcast/PrivacyPolicy.html
@@ -15,7 +15,7 @@
  p.MsoNormal, li.MsoNormal, div.MsoNormal
 	{margin:0in;
 	line-height:150%;
-	font-size:12.0pt;
+	font-size:24.0pt;
 	font-family:Lato;}
 h1
 	{margin-top:20.0pt;

--- a/Psorcast/Psorcast/ProfileTabViewController.swift
+++ b/Psorcast/Psorcast/ProfileTabViewController.swift
@@ -53,6 +53,7 @@ class ProfileTabViewController: UIViewController, UITableViewDelegate, UITableVi
     public static let deepDiveProfileKey = "DeepDive"
     public static let feedbackProfileKey = "feedback"
     public static let withdrawProfileKey = "withdraw"
+    public static let privacyPolicyKey = "privacyPolicy"
     public static let activityMeasuresKey = "activityMeasures"
     
     override open func viewDidLoad() {
@@ -295,6 +296,12 @@ class ProfileTabViewController: UIViewController, UITableViewDelegate, UITableVi
                 self.showJsonTaskViewControler(jsonName: ProfileTabViewController.feedbackTaskId)
             } else if profileItem.profileItemKey == ProfileTabViewController.withdrawProfileKey {
                 self.showJsonTaskViewControler(jsonName: ProfileTabViewController.withdrawalTaskId)
+            } else if profileItem.profileItemKey == ProfileTabViewController.privacyPolicyKey {
+                let privacyURLString = Bundle.main.path(forResource: "PrivacyPolicy", ofType: "html")
+                let webAction = RSDWebViewUIActionObject(url: privacyURLString!, buttonTitle: "Done")
+                let (_, navVC) = RSDWebViewController.instantiateController(using: AppDelegate.designSystem, action: webAction)
+                navVC.modalPresentationStyle = .formSheet
+                self.present(navVC, animated: true, completion: nil)
             } else if let vc = MasterScheduleManager.shared.instantiateSingleQuestionTreatmentTaskController(for: profileItem.profileItemKey) {
                 vc.delegate = self
                 self.show(vc, sender: self)

--- a/Psorcast/Psorcast/ProfileTabViewController.swift
+++ b/Psorcast/Psorcast/ProfileTabViewController.swift
@@ -54,6 +54,7 @@ class ProfileTabViewController: UIViewController, UITableViewDelegate, UITableVi
     public static let feedbackProfileKey = "feedback"
     public static let withdrawProfileKey = "withdraw"
     public static let privacyPolicyKey = "privacyPolicy"
+    public static let studyInformationSheetKey = "studyInformationSheet"
     public static let activityMeasuresKey = "activityMeasures"
     
     override open func viewDidLoad() {
@@ -297,10 +298,14 @@ class ProfileTabViewController: UIViewController, UITableViewDelegate, UITableVi
             } else if profileItem.profileItemKey == ProfileTabViewController.withdrawProfileKey {
                 self.showJsonTaskViewControler(jsonName: ProfileTabViewController.withdrawalTaskId)
             } else if profileItem.profileItemKey == ProfileTabViewController.privacyPolicyKey {
-                let privacyURLString = Bundle.main.path(forResource: "PrivacyPolicy", ofType: "html")
-                let webAction = RSDWebViewUIActionObject(url: privacyURLString!, buttonTitle: "Done")
+                let webAction = RSDWebViewUIActionObject(url: "PrivacyPolicy.html", buttonTitle: "Done")
                 let (_, navVC) = RSDWebViewController.instantiateController(using: AppDelegate.designSystem, action: webAction)
-                navVC.modalPresentationStyle = .formSheet
+                navVC.modalPresentationStyle = .popover
+                self.present(navVC, animated: true, completion: nil)
+            }  else if profileItem.profileItemKey == ProfileTabViewController.studyInformationSheetKey {
+                let webAction = RSDWebViewUIActionObject(url: "ConsentForm.html", buttonTitle: "Done")
+                let (_, navVC) = RSDWebViewController.instantiateController(using: AppDelegate.designSystem, action: webAction)
+                navVC.modalPresentationStyle = .pageSheet
                 self.present(navVC, animated: true, completion: nil)
             } else if let vc = MasterScheduleManager.shared.instantiateSingleQuestionTreatmentTaskController(for: profileItem.profileItemKey) {
                 vc.delegate = self


### PR DESCRIPTION
This adds the privacy policy and consent form as html pages (better experience than PDF imo). Played with sizes, let me know which you like better and I can make them match.

I assumed the consent form was going in the study information sheet section but if that's not the case I can tweak it.

FAQ is also removed from the profile data source on bridge, might need to delete app/reinstall to get it to go away