### PR TITLE
PSR-448

### DIFF
--- a/Psorcast/Psorcast/EnvironmentalStepViewController.swift
+++ b/Psorcast/Psorcast/EnvironmentalStepViewController.swift
@@ -55,7 +55,7 @@ public class EnvironmentalStepViewController: RSDStepViewController, CLLocationM
     var hasAskedLocationPermission = false
     var hasAskedHealthKitPermission = false
     
-    let locationManager = CLLocationManager()
+    var locationManager: CLLocationManager?
     
     open var environmentalStep: EnvironmentalStepObject? {
         return self.step as? EnvironmentalStepObject
@@ -106,8 +106,9 @@ public class EnvironmentalStepViewController: RSDStepViewController, CLLocationM
     override open func goForward() {
         
         guard self.hasAskedLocationPermission else {
-            locationManager.delegate = self
-            locationManager.requestWhenInUseAuthorization()
+            locationManager = CLLocationManager()
+            locationManager?.delegate = self
+            locationManager?.requestWhenInUseAuthorization()
             return
         }
         


### PR DESCRIPTION
It turns out when you would leave that screen, the location manager would become stale, and would not response to "requestWhenInUseAuthorization". Seems like it's possible a bug in apple OS, but I just create the location manager when the button is tapped and it always works that way.