### PR TITLE
Psr 447

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0423F49826DD303B005F4112 /* OnboardingFormStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0423F49726DD303B005F4112 /* OnboardingFormStepObject.swift */; };
 		047C2CCF25F16628006AA52B /* PopTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047C2CCC25F16628006AA52B /* PopTip.swift */; };
 		047C2CD025F16628006AA52B /* PopTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047C2CCC25F16628006AA52B /* PopTip.swift */; };
 		047C2CD125F16628006AA52B /* PopTip+Draw.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047C2CCD25F16628006AA52B /* PopTip+Draw.swift */; };
@@ -411,6 +412,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0423F49726DD303B005F4112 /* OnboardingFormStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFormStepObject.swift; sourceTree = "<group>"; };
 		047C2CCC25F16628006AA52B /* PopTip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopTip.swift; sourceTree = "<group>"; };
 		047C2CCD25F16628006AA52B /* PopTip+Draw.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PopTip+Draw.swift"; sourceTree = "<group>"; };
 		047C2CCE25F16628006AA52B /* PopTip+Transitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PopTip+Transitions.swift"; sourceTree = "<group>"; };
@@ -807,6 +809,7 @@
 				04E61CB02672671000B371E9 /* ConsentReviewStepViewController.swift */,
 				04F2659F268701E6004140B7 /* ConsentQuizStepViewController.swift */,
 				04C9B28526B78E5900DF9CAB /* OnboardingInstructionStepViewController.swift */,
+				0423F49726DD303B005F4112 /* OnboardingFormStepObject.swift */,
 			);
 			name = ViewControllers;
 			sourceTree = "<group>";
@@ -1600,6 +1603,7 @@
 				CB1535E024395410007D0307 /* ProfileTabViewController.swift in Sources */,
 				CBFF926E25E08C3D00EC34DB /* SignInTaskViewController.swift in Sources */,
 				CB6C16DB2477BD5500819FCE /* HistoryItem.swift in Sources */,
+				0423F49826DD303B005F4112 /* OnboardingFormStepObject.swift in Sources */,
 				CBAAB6D92458CB2D00C1A619 /* AtomicBool.swift in Sources */,
 				CBDCDCA923F3849E00E5CEB8 /* PsoriasisDrawStepViewController.swift in Sources */,
 				CB4794F32426B36C00D5A7E6 /* ViewUtils.swift in Sources */,

--- a/Psorcast/Psorcast/AppDelegate.swift
+++ b/Psorcast/Psorcast/AppDelegate.swift
@@ -358,6 +358,17 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate, ShowPopTipDele
 //            self.showConsentScreens(animated: true)
 //            return
 //        }
+        
+        // If we stopped due to canceling, sign out, purge data, and go back to the start
+        if (reason == .discarded) {
+            BridgeSDK.authManager.signOut(completion: { (_, _, error) in
+                DispatchQueue.main.async {
+                    self.resetDefaults(defaults: UserDefaults.standard)
+                    self.resetDefaults(defaults: BridgeSDK.sharedUserDefaults())
+                }
+            })
+            self.showIntroductionScreens(animated: true)
+        }
 
         // If we finish the intro screens, send the user to the try it first task list
         if taskController.task.identifier == self.IntroductionTaskId {
@@ -465,6 +476,13 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate, ShowPopTipDele
     /// This function is called by PopTipProgress when a new pop-tip is requesting to be shown
     func showPopTip(type: PopTipProgress, on viewController: UIViewController) {
         popTipController.showPopTip(type: type, on: viewController)
+    }
+    
+    func resetDefaults(defaults: UserDefaults) {
+        let dictionary = defaults.dictionaryRepresentation()
+        dictionary.keys.forEach { key in
+            defaults.removeObject(forKey: key)
+        }
     }
 }
 

--- a/Psorcast/Psorcast/ConsentQuizStepViewController.swift
+++ b/Psorcast/Psorcast/ConsentQuizStepViewController.swift
@@ -231,10 +231,6 @@ public class ConsentQuizStepViewController: RSDTableStepViewController {
         //
     }
     
-    open override func setupHeader(_ header: RSDStepNavigationView) {
-        super.setupHeader(header)
-        header.cancelButton?.addTarget(self, action: #selector(self.cancelButtonTapped), for: .touchUpInside)
-    }
     
     @objc func incorrectAlertButtonPressed() {
         popinView?.fadeOut()
@@ -249,8 +245,34 @@ public class ConsentQuizStepViewController: RSDTableStepViewController {
         super.goForward()
     }
     
-    @objc func cancelButtonTapped() {
-        goBack()
+    override open func cancel() {
+        processCancel()
+    }
+    
+    open func processCancel() {
+        var actions: [UIAlertAction] = []
+        
+        // Always add a choice to discard the results.
+        let discardResults = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_DISCARD"), style: .destructive) { (_) in
+            self.cancelTask(shouldSave: false)
+        }
+        actions.append(discardResults)
+        
+        // Only add the option to save if the task controller supports it.
+        if self.stepViewModel.rootPathComponent.canSaveTaskProgress() {
+            let saveResults = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_SAVE"), style: .default) { (_) in
+                self.cancelTask(shouldSave: true)
+            }
+            actions.append(saveResults)
+        }
+        
+        // Always add a choice to keep going.
+        let keepGoing = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_CONTINUE"), style: .cancel) { (_) in
+            self.didNotCancel()
+        }
+        actions.append(keepGoing)
+        
+        self.presentAlertWithActions(title: nil, message: Localization.localizedString("CANCEL_CANT_SAVE_TEXT"), preferredStyle: .actionSheet, actions: actions)
     }
 
     

--- a/Psorcast/Psorcast/ConsentReviewStepViewController.swift
+++ b/Psorcast/Psorcast/ConsentReviewStepViewController.swift
@@ -67,6 +67,9 @@ open class ConsentReviewStepViewController: RSDStepViewController, UITextFieldDe
     private var _webviewLoaded = false
     private var _didAddBottomPanel = false
     
+    override open func cancel() {
+        processCancel()
+    }
     
     override open func viewDidLoad() {
         super.viewDidLoad()
@@ -159,6 +162,33 @@ open class ConsentReviewStepViewController: RSDStepViewController, UITextFieldDe
         self.view.addSubview(grayView!)
         grayView?.isHidden = true
     }
+    
+    open func processCancel() {
+        var actions: [UIAlertAction] = []
+        
+        // Always add a choice to discard the results.
+        let discardResults = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_DISCARD"), style: .destructive) { (_) in
+            self.cancelTask(shouldSave: false)
+        }
+        actions.append(discardResults)
+        
+        // Only add the option to save if the task controller supports it.
+        if self.stepViewModel.rootPathComponent.canSaveTaskProgress() {
+            let saveResults = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_SAVE"), style: .default) { (_) in
+                self.cancelTask(shouldSave: true)
+            }
+            actions.append(saveResults)
+        }
+        
+        // Always add a choice to keep going.
+        let keepGoing = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_CONTINUE"), style: .cancel) { (_) in
+            self.didNotCancel()
+        }
+        actions.append(keepGoing)
+        
+        self.presentAlertWithActions(title: nil, message: Localization.localizedString("CANCEL_CANT_SAVE_TEXT"), preferredStyle: .actionSheet, actions: actions)
+    }
+
     
     open override func setupHeader(_ header: RSDStepNavigationView) {
         super.setupHeader(header)

--- a/Psorcast/Psorcast/EnvironmentalStepViewController.swift
+++ b/Psorcast/Psorcast/EnvironmentalStepViewController.swift
@@ -83,10 +83,12 @@ public class EnvironmentalStepViewController: RSDStepViewController, CLLocationM
         super.setupHeader(header)
         
         header.titleLabel?.font = AppDelegate.designSystem.fontRules.font(ofSize: 36, weight: .bold)
+        header.cancelButton?.isHidden = true
     }
     
     override open func setupFooter(_ footer: RSDNavigationFooterView) {
         super.setupFooter(footer)
+        footer.isBackHidden = true
     }
     
     override open func actionTapped(with actionType: RSDUIActionType) -> Bool {

--- a/Psorcast/Psorcast/OnboardingFormStepObject.swift
+++ b/Psorcast/Psorcast/OnboardingFormStepObject.swift
@@ -1,5 +1,5 @@
 //
-//  OnboardingInstructionStepViewController.swift
+//  OnboardingFormStepObject.swift
 //  Psorcast
 //
 //  Copyright © 2021 Sage Bionetworks. All rights reserved.
@@ -37,14 +37,14 @@ import UIKit
 import BridgeApp
 import BridgeAppUI
 
-open class OnboardingInstructionStepObject: RSDUIStepObject, RSDStepViewControllerVendor {
+open class OnboardingFormStepObject: RSDFormUIStepObject, RSDStepViewControllerVendor {
 
     public func instantiateViewController(with parent: RSDPathComponent?) -> (UIViewController & RSDStepController)? {
-        return OnboardingInstructionStepViewController(step: self, parent: parent)
+        return OnboardingFormStepViewController(step: self, parent: parent)
     }
     
     open override class func defaultType() -> RSDStepType {
-        return .onboardingInstruction
+        return .onboardingForm
     }
     
     required public init(identifier: String, type: RSDStepType? = nil) {
@@ -56,41 +56,10 @@ open class OnboardingInstructionStepObject: RSDUIStepObject, RSDStepViewControll
     }
 }
 
-public class OnboardingInstructionStepViewController: RSDInstructionStepViewController {
+public class OnboardingFormStepViewController: RSDTableStepViewController {
     
     override open func cancel() {
         processCancel()
-    }
-    
-    override open func viewDidLoad() {
-        super.viewDidLoad()
-        self.stepTitleLabel?.textAlignment = .center
-    }
-    
-    /// Override `viewWillAppear` to update image placement constraints.
-    override open func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.stepTitleLabel?.textAlignment = .center
-    }
-    
-    override open func updateImageHeightConstraintIfNeeded() {
-        guard let instructionTextView = self.instructionTextView,
-            let scrollView = self.scrollView,
-            let headerTopConstraint = self.imageBackgroundTopConstraint,
-            let headerHeightConstraint = self.headerHeightConstraint
-            else {
-                return
-        }
-        
-        let remainingHeight = scrollView.bounds.height - instructionTextView.bounds.height - headerTopConstraint.constant
-        let minHeight = self.view.bounds.height / 3
-        let height = minHeight
-        if headerHeightConstraint.constant != height {
-            headerHeightConstraint.constant = height
-            self.navigationFooter?.shouldShowShadow = (height != remainingHeight)
-            self.view.setNeedsUpdateConstraints()
-            self.view.setNeedsLayout()
-        }
     }
     
     open func processCancel() {
@@ -118,5 +87,4 @@ public class OnboardingInstructionStepViewController: RSDInstructionStepViewCont
         
         self.presentAlertWithActions(title: nil, message: Localization.localizedString("CANCEL_CANT_SAVE_TEXT"), preferredStyle: .actionSheet, actions: actions)
     }
-
 }

--- a/Psorcast/Psorcast/StudyTaskFactory.swift
+++ b/Psorcast/Psorcast/StudyTaskFactory.swift
@@ -46,6 +46,7 @@ extension RSDStepType {
     public static let withdrawal: RSDStepType = "withdrawal"
     public static let environmental: RSDStepType = "environmental"
     public static let consentQuiz: RSDStepType = "consentQuiz"
+    public static let onboardingForm: RSDStepType = "onboardingForm"
 }
 
 extension RSDStepNavigatorType {
@@ -88,6 +89,8 @@ open class StudyTaskFactory: TaskFactory {
             return try ConsentQuizStepObject(from: decoder)
         case .onboardingInstruction:
             return try OnboardingInstructionStepObject(from: decoder)
+        case .onboardingForm:
+            return try OnboardingFormStepObject(from: decoder)
         default:
             return try super.decodeStep(from: decoder, with: type)
         }

--- a/Psorcast/Psorcast/TreatmentSelectionStepViewController.swift
+++ b/Psorcast/Psorcast/TreatmentSelectionStepViewController.swift
@@ -104,6 +104,10 @@ public class TreatmentSelectionStepViewController: RSDStepViewController, UITabl
     open var treatmentStep: TreatmentSelectionStepObject? {
         return self.step as? TreatmentSelectionStepObject
     }
+    
+    override open func cancel() {
+        processCancel()
+    }
 
     ///
     /// @param  sectionIdentifier the section identifier of the treatments section
@@ -196,6 +200,32 @@ public class TreatmentSelectionStepViewController: RSDStepViewController, UITabl
         
         // This must be called after refreshFilteredTreatments
         self.setupInitialTableViewState()
+    }
+    
+    open func processCancel() {
+        var actions: [UIAlertAction] = []
+        
+        // Always add a choice to discard the results.
+        let discardResults = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_DISCARD"), style: .destructive) { (_) in
+            self.cancelTask(shouldSave: false)
+        }
+        actions.append(discardResults)
+        
+        // Only add the option to save if the task controller supports it.
+        if self.stepViewModel.rootPathComponent.canSaveTaskProgress() {
+            let saveResults = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_SAVE"), style: .default) { (_) in
+                self.cancelTask(shouldSave: true)
+            }
+            actions.append(saveResults)
+        }
+        
+        // Always add a choice to keep going.
+        let keepGoing = UIAlertAction(title: Localization.localizedString("BUTTON_OPTION_CONTINUE"), style: .cancel) { (_) in
+            self.didNotCancel()
+        }
+        actions.append(keepGoing)
+        
+        self.presentAlertWithActions(title: nil, message: Localization.localizedString("CANCEL_CANT_SAVE_TEXT"), preferredStyle: .actionSheet, actions: actions)
     }
     
     func setupInitialTableViewState() {

--- a/Psorcast/PsorcastValidation/Psorcast.strings
+++ b/Psorcast/PsorcastValidation/Psorcast.strings
@@ -119,6 +119,8 @@
 "INSIGHT_NOT_REALLY_BUTTON" = "Not Really";
 "INSIGHTS_COMPLETE_TEXT" = "Thank you from all of us at Psorcast, keep up the great work next week!";
 
+"CANCEL_CANT_SAVE_TEXT" = "Are you sure you want to exit? We will not be able to save your progress if you exit right now.";
+
 "PROFILE_TITLE" = "Your Profile";
 
 "REMINDER_NOTIFICATION_TITLE" = "Time to do your weekly activities";


### PR DESCRIPTION
Add warning to all onboarding screens when canceling
Removed the X cancel at the very last step (and the back as well)
when canceling, log out and delete data

Note: there's a bug I've seen before where the first screens don't work correctly when going back to them later. Exists today as well, but something to look at.