### PR TITLE
PSR-458

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		CB09F00323D649FB009D344E /* DigitalJarOpenInstructionStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB09F00223D649FB009D344E /* DigitalJarOpenInstructionStepViewController.swift */; };
 		CB09F0382421D5730005698D /* TreatmentSelectionStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB09F0372421D5730005698D /* TreatmentSelectionStepViewController.swift */; };
 		CB09F03E2421E9E80005698D /* TreatmentSelectionStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB09F03D2421E9E80005698D /* TreatmentSelectionStepViewController.xib */; };
+		CB0D52B026E9D466009BD911 /* HandPose.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0D52AF26E9D466009BD911 /* HandPose.swift */; };
 		CB144C7A2473346600DF0F6B /* HistoryDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB144C792473346600DF0F6B /* HistoryDataManager.swift */; };
 		CB144C862473B50F00DF0F6B /* History.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = CB144C842473B50F00DF0F6B /* History.xcdatamodeld */; };
 		CB144C8E24760D5800DF0F6B /* ImageDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB144C8D24760D5700DF0F6B /* ImageDataManager.swift */; };
@@ -452,6 +453,7 @@
 		CB09F00223D649FB009D344E /* DigitalJarOpenInstructionStepViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DigitalJarOpenInstructionStepViewController.swift; sourceTree = "<group>"; };
 		CB09F0372421D5730005698D /* TreatmentSelectionStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreatmentSelectionStepViewController.swift; sourceTree = "<group>"; };
 		CB09F03D2421E9E80005698D /* TreatmentSelectionStepViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TreatmentSelectionStepViewController.xib; sourceTree = "<group>"; };
+		CB0D52AF26E9D466009BD911 /* HandPose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandPose.swift; sourceTree = "<group>"; };
 		CB144C792473346600DF0F6B /* HistoryDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDataManager.swift; sourceTree = "<group>"; };
 		CB144C852473B50F00DF0F6B /* History.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = History.xcdatamodel; sourceTree = "<group>"; };
 		CB144C8D24760D5700DF0F6B /* ImageDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageDataManager.swift; sourceTree = "<group>"; };
@@ -731,6 +733,14 @@
 			name = MP4;
 			sourceTree = "<group>";
 		};
+		CB0D52AA26E9D457009BD911 /* Vision */ = {
+			isa = PBXGroup;
+			children = (
+				CB0D52AF26E9D466009BD911 /* HandPose.swift */,
+			);
+			name = Vision;
+			sourceTree = "<group>";
+		};
 		CB2219A424611FC4007546CD /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -905,6 +915,7 @@
 		CBBE0F6024039A4F0072452C /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				CB0D52AA26E9D457009BD911 /* Vision */,
 				CBB0F4382643D173007442F3 /* PassiveData */,
 				CBBDC395247787D20017A304 /* HistoryDataManager */,
 				CB8F7D512422D73900F77D62 /* StudyTaskFactory.swift */,
@@ -1572,6 +1583,7 @@
 				CBDCDC9B23F3849E00E5CEB8 /* JointPainResultObject.swift in Sources */,
 				CB73F7ED2630FDC200969688 /* PsorcastIdentifiers.swift in Sources */,
 				CB95A2862608540600F28273 /* OnboardingPagerStepObject.swift in Sources */,
+				CB0D52B026E9D466009BD911 /* HandPose.swift in Sources */,
 				CBDCDCAF23F3849E00E5CEB8 /* PsoriasisDrawCompletionStepViewController.swift in Sources */,
 				CBDCDC9A23F3849E00E5CEB8 /* JointPainStepObject.swift in Sources */,
 				CBFF927A25E1783B00EC34DB /* RegistrationWaitingViewController.swift in Sources */,

--- a/Psorcast/Psorcast/HandPose.swift
+++ b/Psorcast/Psorcast/HandPose.swift
@@ -1,0 +1,285 @@
+//
+//  HandPose.swift
+//  Psorcast
+//
+//  Copyright © 2021 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import Vision
+import AVFoundation
+
+open class HandPose {
+    
+    var accuracy: CGFloat = CGFloat.zero
+    
+    var thumbTip: CGPoint? = nil
+    var thumbIp: CGPoint? = nil
+    var thumbMp: CGPoint? = nil
+    var thumbCmc: CGPoint? = nil
+    var indexTip: CGPoint? = nil
+    var indexDip: CGPoint? = nil
+    var indexPip: CGPoint? = nil
+    var indexMcp: CGPoint? = nil
+    var middleTip: CGPoint? = nil
+    var middleDip: CGPoint? = nil
+    var middlePip: CGPoint? = nil
+    var middleMcp: CGPoint? = nil
+    var ringTip: CGPoint? = nil
+    var ringDip: CGPoint? = nil
+    var ringPip: CGPoint? = nil
+    var ringMcp: CGPoint? = nil
+    var littleTip: CGPoint? = nil
+    var littleDip: CGPoint? = nil
+    var littlePip: CGPoint? = nil
+    var littleMcp: CGPoint? = nil
+    var wrist: CGPoint? = nil
+    
+    func thumbDrawPoints() -> [CGPoint]? {
+        guard let tip = thumbTip, let ip = thumbIp, let mp = thumbMp,
+              let cmc = thumbCmc, let wr = wrist else {
+            return nil
+        }
+        return [tip, ip, mp, cmc, wr]
+    }
+    
+    func indexDrawPoints() -> [CGPoint]? {
+        guard let tip = indexTip, let dip = indexDip, let pip = indexPip,
+              let mcp = indexMcp, let wr = wrist else {
+            return nil
+        }
+        return [tip, dip, pip, mcp, wr]
+    }
+    
+    func middleDrawPoints() -> [CGPoint]? {
+        guard let tip = middleTip, let dip = middleDip, let pip = middlePip,
+              let mcp = middleMcp, let wr = wrist else {
+            return nil
+        }
+        return [tip, dip, pip, mcp, wr]
+    }
+   
+    func ringDrawPoints() -> [CGPoint]? {
+        guard let tip = ringTip, let dip = ringDip, let pip = ringPip,
+              let mcp = ringMcp, let wr = wrist else {
+            return nil
+        }
+        return [tip, dip, pip, mcp, wr]
+    }
+    
+    func littleDrawPoints() -> [CGPoint]? {
+        guard let tip = littleTip, let dip = littleDip, let pip = littlePip,
+              let mcp = littleMcp, let wr = wrist else {
+            return nil
+        }
+        return [tip, dip, pip, mcp, wr]
+    }
+    
+    @available(iOS 14.0, *)
+    public static func create(observation: VNHumanHandPoseObservation) -> HandPose? {
+        
+        let hand = HandPose()
+        
+        do {
+            let thumbPoints = try observation.recognizedPoints(.thumb)
+            let indexFingerPoints = try observation.recognizedPoints(.indexFinger)
+            let middleFingerPoints = try observation.recognizedPoints(.middleFinger)
+            let ringFingerPoints = try observation.recognizedPoints(.ringFinger)
+            let littleFingerPoints = try observation.recognizedPoints(.littleFinger)
+            let wristPoints = try observation.recognizedPoints(.all)
+
+            // Look for tip points.
+            guard let thumbTipPoint = thumbPoints[.thumbTip],
+                  let thumbIpPoint = thumbPoints[.thumbIP],
+                  let thumbMpPoint = thumbPoints[.thumbMP],
+                  let thumbCMCPoint = thumbPoints[.thumbCMC] else {
+                return nil
+            }
+
+            guard let indexTipPoint = indexFingerPoints[.indexTip],
+                  let indexDipPoint = indexFingerPoints[.indexDIP],
+                  let indexPipPoint = indexFingerPoints[.indexPIP],
+                  let indexMcpPoint = indexFingerPoints[.indexMCP] else {
+                return nil
+            }
+
+            guard let middleTipPoint = middleFingerPoints[.middleTip],
+                  let middleDipPoint = middleFingerPoints[.middleDIP],
+                  let middlePipPoint = middleFingerPoints[.middlePIP],
+                  let middleMcpPoint = middleFingerPoints[.middleMCP] else {
+                return nil
+            }
+
+            guard let ringTipPoint = ringFingerPoints[.ringTip],
+                  let ringDipPoint = ringFingerPoints[.ringDIP],
+                  let ringPipPoint = ringFingerPoints[.ringPIP],
+                  let ringMcpPoint = ringFingerPoints[.ringMCP] else {
+                return nil
+            }
+
+            guard let littleTipPoint = littleFingerPoints[.littleTip],
+                  let littleDipPoint = littleFingerPoints[.littleDIP],
+                  let littlePipPoint = littleFingerPoints[.littlePIP],
+                  let littleMcpPoint = littleFingerPoints[.littleMCP] else {
+                return nil
+            }
+
+            guard let wristPoint = wristPoints[.wrist] else {
+                return nil
+            }
+
+            let minimumConfidence: Float = 0.3
+            
+            // Ignore low confidence points.
+            guard thumbTipPoint.confidence > minimumConfidence,
+                  thumbIpPoint.confidence > minimumConfidence,
+                  thumbMpPoint.confidence > minimumConfidence,
+                  thumbCMCPoint.confidence > minimumConfidence else {
+                return nil
+            }
+            
+            guard indexTipPoint.confidence > minimumConfidence,
+                  indexDipPoint.confidence > minimumConfidence,
+                  indexPipPoint.confidence > minimumConfidence,
+                  indexMcpPoint.confidence > minimumConfidence else {
+                return nil
+            }
+
+            guard middleTipPoint.confidence > minimumConfidence,
+                  middleDipPoint.confidence > minimumConfidence,
+                  middlePipPoint.confidence > minimumConfidence,
+                  middleMcpPoint.confidence > minimumConfidence else {
+                return nil
+            }
+
+            guard ringTipPoint.confidence > minimumConfidence,
+                  ringDipPoint.confidence > minimumConfidence,
+                  ringPipPoint.confidence > minimumConfidence,
+                  ringMcpPoint.confidence > minimumConfidence else {
+                return nil
+            }
+
+            guard littleTipPoint.confidence > minimumConfidence,
+                  littleDipPoint.confidence > minimumConfidence,
+                  littlePipPoint.confidence > minimumConfidence,
+                  littleMcpPoint.confidence > minimumConfidence else {
+                return nil
+            }
+
+            guard wristPoint.confidence > minimumConfidence else {
+                return nil
+            }
+
+            // Convert points from Vision coordinates to AVFoundation coordinates.
+            hand.thumbTip = CGPoint(x: thumbTipPoint.location.x, y: 1 - thumbTipPoint.location.y)
+            hand.thumbIp = CGPoint(x: thumbIpPoint.location.x, y: 1 - thumbIpPoint.location.y)
+            hand.thumbMp = CGPoint(x: thumbMpPoint.location.x, y: 1 - thumbMpPoint.location.y)
+            hand.thumbCmc = CGPoint(x: thumbCMCPoint.location.x, y: 1 - thumbCMCPoint.location.y)
+            hand.indexTip = CGPoint(x: indexTipPoint.location.x, y: 1 - indexTipPoint.location.y)
+            hand.indexDip = CGPoint(x: indexDipPoint.location.x, y: 1 - indexDipPoint.location.y)
+            hand.indexPip = CGPoint(x: indexPipPoint.location.x, y: 1 - indexPipPoint.location.y)
+            hand.indexMcp = CGPoint(x: indexMcpPoint.location.x, y: 1 - indexMcpPoint.location.y)
+            hand.middleTip = CGPoint(x: middleTipPoint.location.x, y: 1 - middleTipPoint.location.y)
+            hand.middleDip = CGPoint(x: middleDipPoint.location.x, y: 1 - middleDipPoint.location.y)
+            hand.middlePip = CGPoint(x: middlePipPoint.location.x, y: 1 - middlePipPoint.location.y)
+            hand.middleMcp = CGPoint(x: middleMcpPoint.location.x, y: 1 - middleMcpPoint.location.y)
+            hand.ringTip = CGPoint(x: ringTipPoint.location.x, y: 1 - ringTipPoint.location.y)
+            hand.ringDip = CGPoint(x: ringDipPoint.location.x, y: 1 - ringDipPoint.location.y)
+            hand.ringPip = CGPoint(x: ringPipPoint.location.x, y: 1 - ringPipPoint.location.y)
+            hand.ringMcp = CGPoint(x: ringMcpPoint.location.x, y: 1 - ringMcpPoint.location.y)
+            hand.littleTip = CGPoint(x: littleTipPoint.location.x, y: 1 - littleTipPoint.location.y)
+            hand.littleDip = CGPoint(x: littleDipPoint.location.x, y: 1 - littleDipPoint.location.y)
+            hand.littlePip = CGPoint(x: littlePipPoint.location.x, y: 1 - littlePipPoint.location.y)
+            hand.littleMcp = CGPoint(x: littleMcpPoint.location.x, y: 1 - littleMcpPoint.location.y)
+            hand.wrist = CGPoint(x: wristPoint.location.x, y: 1 - wristPoint.location.y)
+            
+            
+        } catch {
+            print("Cannot perform hand pose tracking")
+            return nil
+        }
+        
+        return hand
+    }
+    
+    public func createHand(videoPreviewLayer: AVCaptureVideoPreviewLayer) -> [CAShapeLayer] {
+        guard let thumb = thumbDrawPoints(),
+              let index = indexDrawPoints(),
+              let middle = middleDrawPoints(),
+              let ring = ringDrawPoints(),
+              let little = littleDrawPoints() else {
+            return []
+        }
+        
+        var lineLayers: [CAShapeLayer] = []
+        var circleLayers: [CAShapeLayer] = []
+        var lastPosition: CGPoint? = nil
+        
+        [thumb, index, middle, ring, little].forEach { (jointGroup) in
+            lastPosition = nil
+            for (_, joint) in jointGroup.enumerated() {
+                let jointPos = videoPreviewLayer.layerPointConverted(fromCaptureDevicePoint: joint)
+                if let lastPosUnwrapped = lastPosition {
+                    lineLayers.append(createLine(pointA: jointPos, pointB: lastPosUnwrapped))
+                }
+                circleLayers.append(createCircle(point: jointPos))
+                lastPosition = jointPos
+            }
+        }
+        
+        var shapeLayers: [CAShapeLayer] = []
+        shapeLayers.append(contentsOf: lineLayers)
+        shapeLayers.append(contentsOf: circleLayers)
+        
+        return shapeLayers
+    }
+    
+    func createLine(pointA: CGPoint, pointB: CGPoint) -> CAShapeLayer {
+        let line = CAShapeLayer()
+        line.lineCap = .round
+        line.strokeColor = AppDelegate.designSystem.colorRules.backgroundPrimary.color.cgColor
+        line.fillColor = AppDelegate.designSystem.colorRules.backgroundPrimary.color.cgColor
+        
+        let linePath = UIBezierPath()
+        linePath.move(to: pointA)
+        linePath.addLine(to: pointB)
+        
+        line.path = linePath.cgPath
+        return line
+    }
+    
+    func createCircle(point: CGPoint) -> CAShapeLayer {
+        let circle = CAShapeLayer()
+        circle.fillColor = AppDelegate.designSystem.colorRules.backgroundPrimary.color.cgColor
+        circle.lineCap = .round
+        circle.strokeColor = AppDelegate.designSystem.colorRules.palette.secondary.normal.color.cgColor
+        circle.path = UIBezierPath(ovalIn: CGRect(x: point.x - 6, y: point.y - 6, width: 12, height: 12)).cgPath
+        return circle
+    }
+}

--- a/Psorcast/PsorcastValidation/ImageCaptureStepViewController.xib
+++ b/Psorcast/PsorcastValidation/ImageCaptureStepViewController.xib
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="cameraToggleButton" destination="z7Q-cL-s9u" id="v4B-LD-Orv"/>
                 <outlet property="captureButton" destination="7Iz-4x-dLZ" id="b5R-jR-RN4"/>
+                <outlet property="handOverlayView" destination="Ln8-EY-YfR" id="EAO-cl-lnY"/>
                 <outlet property="navigationHeader" destination="fxA-Tz-ZiS" id="agX-5m-P7G"/>
                 <outlet property="previewView" destination="Bb7-gd-Spk" id="gx5-ZP-Ljt"/>
                 <outlet property="view" destination="Be1-UX-e65" id="eci-s9-hNP"/>
@@ -83,19 +84,27 @@
                                 <action selector="changeCamera:" destination="-1" eventType="touchUpInside" id="t6y-2m-w11"/>
                             </connections>
                         </button>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ln8-EY-YfR" userLabel="Hand Overlay">
+                            <rect key="frame" x="0.0" y="80" width="395" height="484"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
+                        <constraint firstItem="Ln8-EY-YfR" firstAttribute="trailing" secondItem="Bb7-gd-Spk" secondAttribute="trailing" id="2fV-Si-Mt4"/>
                         <constraint firstAttribute="trailing" secondItem="fxA-Tz-ZiS" secondAttribute="trailing" id="3JV-je-hxC"/>
                         <constraint firstAttribute="trailing" secondItem="Bb7-gd-Spk" secondAttribute="trailing" id="Bd0-Lg-k57"/>
                         <constraint firstAttribute="bottom" secondItem="Br6-tq-bnk" secondAttribute="bottom" constant="24" id="Bnl-m2-DkF"/>
+                        <constraint firstItem="Ln8-EY-YfR" firstAttribute="top" secondItem="Bb7-gd-Spk" secondAttribute="top" id="JvG-DY-Uxg"/>
                         <constraint firstItem="z7Q-cL-s9u" firstAttribute="top" secondItem="fxA-Tz-ZiS" secondAttribute="bottom" id="MwW-H9-neu"/>
                         <constraint firstItem="Br6-tq-bnk" firstAttribute="top" secondItem="7Iz-4x-dLZ" secondAttribute="bottom" constant="8" id="Nl3-Uq-fax"/>
                         <constraint firstItem="7Iz-4x-dLZ" firstAttribute="centerX" secondItem="nCy-4g-nIJ" secondAttribute="centerX" id="Otr-xa-UAw"/>
                         <constraint firstItem="fxA-Tz-ZiS" firstAttribute="top" secondItem="nCy-4g-nIJ" secondAttribute="top" id="SC4-I8-O5N"/>
                         <constraint firstAttribute="trailing" secondItem="z7Q-cL-s9u" secondAttribute="trailing" id="cEu-Oj-CcG"/>
+                        <constraint firstItem="Ln8-EY-YfR" firstAttribute="leading" secondItem="Bb7-gd-Spk" secondAttribute="leading" id="lXN-XC-P0D"/>
                         <constraint firstItem="Bb7-gd-Spk" firstAttribute="leading" secondItem="nCy-4g-nIJ" secondAttribute="leading" id="mgY-QI-c9q"/>
                         <constraint firstItem="Bb7-gd-Spk" firstAttribute="top" secondItem="fxA-Tz-ZiS" secondAttribute="bottom" id="pki-Yv-2aA"/>
+                        <constraint firstItem="Ln8-EY-YfR" firstAttribute="bottom" secondItem="Bb7-gd-Spk" secondAttribute="bottom" id="q3H-E8-XJM"/>
                         <constraint firstItem="fxA-Tz-ZiS" firstAttribute="leading" secondItem="nCy-4g-nIJ" secondAttribute="leading" id="rEg-ZD-hZb"/>
                         <constraint firstAttribute="bottom" secondItem="Bb7-gd-Spk" secondAttribute="bottom" constant="156" id="t2M-kq-AFr"/>
                         <constraint firstItem="Br6-tq-bnk" firstAttribute="centerX" secondItem="nCy-4g-nIJ" secondAttribute="centerX" id="xYT-Ri-THY"/>


### PR DESCRIPTION
Added iOS 14+ hand tracking using a mixture of code from these two [Source 1](https://medium.com/snowdog-labs/hand-pose-with-vision-framework-69ae61220669) and [Source 2](https://www.raywenderlich.com/19454476-vision-tutorial-for-ios-detect-body-and-hand-pose).

The hand tracking returns a list of joints and the location of each with the algorithm confidence.  The confidence threshold for showing the hand overlay is 0.3 / 1.0.  This was the default in Source 1, and seems to work nicely with hiding the hand overlay after 1 second of inaccurate results.  

The hand is drawn using lines and circle shapes in the HandPose class.

@DanWebster this needs tested to see if it works as usual, but without hand tracking on iOS < 14.  All of my devices are updated unfortunately.