### PR TITLE
PSR-459

### DIFF
--- a/Psorcast/Psorcast/MeasureTabViewController.swift
+++ b/Psorcast/Psorcast/MeasureTabViewController.swift
@@ -211,6 +211,11 @@ open class MeasureTabViewController: UIViewController, UICollectionViewDataSourc
               let analytics = (AppDelegate.shared as? AppDelegate)?.analyticsDefaults else {
             return
         }
+        
+        // Review tab analytics
+        MasterScheduleManager.shared.uploadReviewTabAnalyticsIfNeeded()
+        
+        // Try before you buy analytics
         if (analytics.object(forKey: "TryItFirstCount") == nil) {
             MasterScheduleManager.shared.uploadAnalyticsTryBeforeYouBuy(count: 0)
             analytics.setValue(0, forKey: "TryItFirstCount")

--- a/Psorcast/Psorcast/ReviewTabViewController.swift
+++ b/Psorcast/Psorcast/ReviewTabViewController.swift
@@ -211,6 +211,9 @@ open class ReviewTabViewController: UIViewController, UITableViewDataSource, UIT
         if shouldRefreshUi {
             self.refreshTreatmentContent()
         }
+        
+        // Save analytics
+        MasterScheduleManager.shared.userLookedAtReviewTab()    
     }
     
     func refreshTreatmentContent() {
@@ -475,9 +478,17 @@ open class ReviewTabViewController: UIViewController, UITableViewDataSource, UIT
         self.requestPermission {
             if let frame = renderFrame {
                 self.userHasPermissionToSaveToLibary(renderFrame: frame, taskId: taskIdentifier, cellIdx: cellIdx)
+                
+                // Save analytics
+                MasterScheduleManager.shared.userUsedReviewTabFeature(isImage: true, type: taskIdentifier.rawValue)
+                
             } else if let filteredStartDate = self.selectedTreatmentRange?.startDate,
                 let videoUrl = self.imageManager.findVideoUrl(for: taskIdentifier.rawValue, with: filteredStartDate) {
+                                
                 self.userHasPermissionToSaveToLibary(video: videoUrl, taskId: taskIdentifier, cellIdx: cellIdx)
+                
+                // Save analytics
+                MasterScheduleManager.shared.userUsedReviewTabFeature(isImage: false, type: taskIdentifier.rawValue)
             }
         }
     }


### PR DESCRIPTION
Added review tab analytics every time the user lands on the review tab, or whenever the user exports a an image or movie successfully.

Every time the user lands on the home screen, it will check if a week has gone by since the last review tab analytics upload. If a week has gone by, it will be uploaded to bridge and reset to empty arrays.

To test the upload, force quite the app, move your device forward 7+ days and open the app.