### PR TITLE
PSR 469

### DIFF
--- a/Psorcast/Psorcast/HistoryDataManager.swift
+++ b/Psorcast/Psorcast/HistoryDataManager.swift
@@ -103,6 +103,12 @@ open class HistoryDataManager {
     public var pastInsightItemsViewed: [InsightItemViewed] {
         return self.insightData?.current ?? []
     }
+    public var insightFinishedShownWeek: Int {
+        return self.defaults.integer(forKey: "InsightSuccessLastViewedWeek")
+    }
+    public func setInsightFinishedShownWeek(week: Int) {
+        self.defaults.set(week, forKey: "InsightSuccessLastViewedWeek")
+    }
     
     fileprivate var reminderData: RemindersUserDefaultsSingletonReport? {
         return self.singletonData[RSDIdentifier.remindersTask] as? RemindersUserDefaultsSingletonReport

--- a/Psorcast/Psorcast/MeasureTabViewController.swift
+++ b/Psorcast/Psorcast/MeasureTabViewController.swift
@@ -490,8 +490,16 @@ open class MeasureTabViewController: UIViewController, UICollectionViewDataSourc
                 if (self.scheduleManager.nextInsightItem() != nil) {
                     self.animateInsightAchievedView(hide: false)
                 } else {
-                    // We've shown all the insights, so let's show the insights complete view
-                    self.animateInsightsCompleteView()
+                    // We've shown all the insights, so let's show the insights complete view, but only if
+                    // we haven't already viewed it this week
+                    let lastSuccessWeek = self.historyData.insightFinishedShownWeek
+                    // Check to see if we've shown this already this week. If not, animate and update. If
+                    // it's already been seen, don't animate.
+                    if (lastSuccessWeek != self.treatmentWeek()) {
+                        // show the success view, and update the date
+                        self.animateInsightsCompleteView()
+                        self.historyData.setInsightFinishedShownWeek(week: self.treatmentWeek())
+                    }
                 }
             } else if animateToInsightProgressView {
                 // Animate in the no insight view if it was previously hidden


### PR DESCRIPTION
We already had logic to make sure if we'd already seen the insight thing pop up and viewed the insight, we don't show the insight available screen again. However, there were some assumptions in the code that there was a next insight to view that weren't properly updated in the "no insights remaining" scenario. This tracks the week we've seen this success page and updates it when appropriate so we don't keep showing it.