### PR TITLE
PSR-494

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		CBB5C41F26EBDE1C000688CD /* HandPose.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0D52AF26E9D466009BD911 /* HandPose.swift */; };
 		CBB5C42226EBDE5C000688CD /* BackgroundNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E8C6A5266019B600AA906A /* BackgroundNetworkManager.swift */; };
 		CBB78870246CB85F004385AF /* DeepDiveReportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB7886F246CB85F004385AF /* DeepDiveReportManager.swift */; };
+		CBB7D3EA272C67C200CE9865 /* LinkerStudiesUserDefaultsSingletonReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB7D3E5272C67C200CE9865 /* LinkerStudiesUserDefaultsSingletonReport.swift */; };
 		CBB90AE82381FF8700F1DFA4 /* PsoriasisAreaPhoto.mov in Resources */ = {isa = PBXBuildFile; fileRef = CBB90AE52381FF8500F1DFA4 /* PsoriasisAreaPhoto.mov */; };
 		CBB90AE92381FF8700F1DFA4 /* FingersPhoto.mov in Resources */ = {isa = PBXBuildFile; fileRef = CBB90AE62381FF8600F1DFA4 /* FingersPhoto.mov */; };
 		CBB90AEA2381FF8700F1DFA4 /* ToesPhoto.mov in Resources */ = {isa = PBXBuildFile; fileRef = CBB90AE72381FF8700F1DFA4 /* ToesPhoto.mov */; };
@@ -591,6 +592,7 @@
 		CBB0F4322643D0C7007442F3 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		CBB0F4392643D1B0007442F3 /* PassiveDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassiveDataManager.swift; sourceTree = "<group>"; };
 		CBB7886F246CB85F004385AF /* DeepDiveReportManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepDiveReportManager.swift; sourceTree = "<group>"; };
+		CBB7D3E5272C67C200CE9865 /* LinkerStudiesUserDefaultsSingletonReport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkerStudiesUserDefaultsSingletonReport.swift; sourceTree = "<group>"; };
 		CBB90AE52381FF8500F1DFA4 /* PsoriasisAreaPhoto.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = PsoriasisAreaPhoto.mov; sourceTree = "<group>"; };
 		CBB90AE62381FF8600F1DFA4 /* FingersPhoto.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = FingersPhoto.mov; sourceTree = "<group>"; };
 		CBB90AE72381FF8700F1DFA4 /* ToesPhoto.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = ToesPhoto.mov; sourceTree = "<group>"; };
@@ -927,6 +929,7 @@
 				CBBDC393247787AA0017A304 /* TreatmentUserDefaultsSingletonReport.swift */,
 				CBBDC396247788720017A304 /* RemindersUserDefaultsSingletonReport.swift */,
 				CBBDC3982477A3350017A304 /* InsightsUserDefaultsSingletonReport.swift */,
+				CBB7D3E5272C67C200CE9865 /* LinkerStudiesUserDefaultsSingletonReport.swift */,
 				CB6C16DA2477BD5500819FCE /* HistoryItem.swift */,
 			);
 			name = HistoryDataManager;
@@ -1684,6 +1687,7 @@
 				CBBDC397247788720017A304 /* RemindersUserDefaultsSingletonReport.swift in Sources */,
 				CBDCDC9C23F3849E00E5CEB8 /* JointPainImageView.swift in Sources */,
 				CB508BFB26713F15008B54D5 /* SandboxImageApiViewController.swift in Sources */,
+				CBB7D3EA272C67C200CE9865 /* LinkerStudiesUserDefaultsSingletonReport.swift in Sources */,
 				CBDCDC8F23F3849E00E5CEB8 /* ExternalIDRegistrationViewController.swift in Sources */,
 				CBAF1DA92437CB2A00ECC699 /* StudyExternalIdRegistrationViewController.swift in Sources */,
 				CB16C38924465BB80046E200 /* ReminderManager.swift in Sources */,

--- a/Psorcast/Psorcast/AppDelegate.swift
+++ b/Psorcast/Psorcast/AppDelegate.swift
@@ -423,6 +423,7 @@ class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate, ShowPopTipDele
         
         if taskController.task.identifier == self.ConsentTaskId {
             if reason == .completed {
+                HistoryDataManager.shared.studyDateData?.initializedStudyDates(startDate: Date())
                 self.showTreatmentSelectionScreens(animated: true)
                 return
             } else {

--- a/Psorcast/Psorcast/HistoryDataManager.swift
+++ b/Psorcast/Psorcast/HistoryDataManager.swift
@@ -37,6 +37,9 @@ import ResearchUI
 
 open class HistoryDataManager {
     
+    public static let LINKER_STUDY_DEFAULT = "PsorcastUS"
+    public static let LINKER_STUDY_BETA_2021 = "BETA2021"
+    
     /// For encoding report client data
     lazy var jsonEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
@@ -98,6 +101,14 @@ open class HistoryDataManager {
     
     public var studyDateData: LinkerStudiesUserDefaultsSingletonReport? {
         return self.singletonData[RSDIdentifier.studyDates] as? LinkerStudiesUserDefaultsSingletonReport
+    }
+    
+    public func studyStartDate(for identifier: String) -> Date? {
+        self.studyDateData?.current?.first(where: { $0.identifier == identifier })?.startDate
+    }
+    
+    public var baseStudyStartDate: Date? {
+        return self.studyStartDate(for: HistoryDataManager.LINKER_STUDY_DEFAULT)
     }
     
     fileprivate var insightData: InsightsUserDefaultsSingletonReport? {

--- a/Psorcast/Psorcast/LinkerStudiesUserDefaultsSingletonReport.swift
+++ b/Psorcast/Psorcast/LinkerStudiesUserDefaultsSingletonReport.swift
@@ -33,10 +33,7 @@
 
 import BridgeApp
 
-open class LinkerStudiesUserDefaultsSingletonReport: UserDefaultsSingletonReport {
-    
-    public static let LINKER_STUDY_DEFAULT = "PsorcastUS"
-    public static let LINKER_STUDY_BETA_2021 = "BETA2021"
+open class LinkerStudiesUserDefaultsSingletonReport: UserDefaultsSingletonReport {        
     
     var _current: [LinkerStudy]?
     var current: [LinkerStudy]? {
@@ -73,8 +70,8 @@ open class LinkerStudiesUserDefaultsSingletonReport: UserDefaultsSingletonReport
     /// it is because the user just signed up and this func needs called
     open func initializedStudyDates(startDate: Date) {
         var items = [LinkerStudy]()
-        items.append(LinkerStudy(identifier: LinkerStudiesUserDefaultsSingletonReport.LINKER_STUDY_DEFAULT, startDate: startDate))
-        items.append(LinkerStudy(identifier: LinkerStudiesUserDefaultsSingletonReport.LINKER_STUDY_BETA_2021, startDate: startDate))
+        items.append(LinkerStudy(identifier: HistoryDataManager.LINKER_STUDY_DEFAULT, startDate: startDate))
+        items.append(LinkerStudy(identifier: HistoryDataManager.LINKER_STUDY_BETA_2021, startDate: startDate))
         // Signal that the new state needs synced with Bridge
         self.append(items: items)
     }

--- a/Psorcast/Psorcast/LinkerStudiesUserDefaultsSingletonReport.swift
+++ b/Psorcast/Psorcast/LinkerStudiesUserDefaultsSingletonReport.swift
@@ -1,8 +1,8 @@
 //
-//  InsightsUserDefaultsSingletonReport.swift
+//  LinkerStudiesUserDefaultsSingletonReport.swift
 //  Psorcast
 //
-//  Copyright © 2020 Sage Bionetworks. All rights reserved.
+//  Copyright © 2021 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -33,23 +33,26 @@
 
 import BridgeApp
 
-open class InsightsUserDefaultsSingletonReport: UserDefaultsSingletonReport {    
+open class LinkerStudiesUserDefaultsSingletonReport: UserDefaultsSingletonReport {
     
-    var _current: [InsightItemViewed]?
-    var current: [InsightItemViewed]? {
+    public static let LINKER_STUDY_DEFAULT = "PsorcastUS"
+    public static let LINKER_STUDY_BETA_2021 = "BETA2021"
+    
+    var _current: [LinkerStudy]?
+    var current: [LinkerStudy]? {
         if _current != nil { return _current }
         guard let jsonStr = self.defaults.data(forKey: "\(identifier)JsonValue") else { return nil }
         do {
-            _current = try HistoryDataManager.shared.jsonDecoder.decode([InsightItemViewed].self, from: jsonStr)
+            _current = try HistoryDataManager.shared.jsonDecoder.decode([LinkerStudy].self, from: jsonStr)
             return _current
         } catch {
             debugPrint("Error decoding reminders json \(error)")
         }
         return nil
     }
-    func setCurrent(_ items: [InsightItemViewed]) {
+    func setCurrent(_ items: [LinkerStudy]) {
         _current = items
-        NotificationCenter.default.post(name: HistoryDataManager.insightsChanged, object: nil)
+        NotificationCenter.default.post(name: HistoryDataManager.studyDatesChanged, object: nil)
         do {
             let jsonData = try HistoryDataManager.shared.jsonEncoder.encode(items)
             self.defaults.set(jsonData, forKey: "\(identifier)JsonValue")
@@ -59,50 +62,50 @@ open class InsightsUserDefaultsSingletonReport: UserDefaultsSingletonReport {
     }
     
     public override init(identifier: RSDIdentifier) {
-        super.init(identifier: RSDIdentifier.insightsTask)
+        super.init(identifier: RSDIdentifier.studyDates)
     }
     
     public init() {
-        super.init(identifier: RSDIdentifier.insightsTask)
+        super.init(identifier: RSDIdentifier.studyDates)
+    }
+    
+    /// At this point, if we do not have any linker study items,
+    /// it is because the user just signed up and this func needs called
+    open func initializedStudyDates(startDate: Date) {
+        var items = [LinkerStudy]()
+        items.append(LinkerStudy(identifier: LinkerStudiesUserDefaultsSingletonReport.LINKER_STUDY_DEFAULT, startDate: startDate))
+        items.append(LinkerStudy(identifier: LinkerStudiesUserDefaultsSingletonReport.LINKER_STUDY_BETA_2021, startDate: startDate))
+        // Signal that the new state needs synced with Bridge
+        self.append(items: items)
+    }
+    
+    open func append(items: [LinkerStudy]) {
+        let merged = self.mergeAndSortItems(cached: self.current ?? [], newItems: items)
+        self.setCurrent(merged)
+        self.syncToBridge()
     }
 
     override open func append(taskResult: RSDTaskResult) {
-        // No need for a recursive solution as we don't have nested results
-        guard let insightId = taskResult.findAnswerResult(with: InsightResultIdentifier.insightViewedIdentifier.rawValue.rawValue)?.value as? String else {
-            print("Invalid reminders task result data")
-            return
-        }
-                
-        let item = InsightItemViewed(insightIdentifier: insightId, date: taskResult.endDate)
-        let merged = self.mergeAndSortItems(cached: self.current ?? [], newItems: [item])
-        self.setCurrent(merged)
-        
-        self.syncToBridge()
+        // Not needed, as this is not how this is updated, see func above
     }
-    
-    // TODO: mdephillips unit test this function
-    func mergeAndSortItems(cached: [InsightItemViewed], newItems: [InsightItemViewed]) -> [InsightItemViewed] {
         
-        var merged = [InsightItemViewed]()
+    func mergeAndSortItems(cached: [LinkerStudy], newItems: [LinkerStudy]) -> [LinkerStudy] {
         
+        var merged = [LinkerStudy]()
+        
+        // Add all unique data group elements
         cached.forEach { (item) in
-            if let same = newItems.first(where: { $0.insightIdentifier == item.insightIdentifier }),
-                (same.date?.timeIntervalSince1970 ?? 0) > (item.date?.timeIntervalSince1970 ?? 0) {
-                // Add the newer bridge one instead
-                merged.append(same)
-            } else {
+            if (!merged.contains(where: { $0.identifier == item.identifier })) {
                 merged.append(item)
             }
         }
-        
-        // Add in all new unique insight items
         newItems.forEach { (item) in
-            if !merged.contains(where: { $0.insightIdentifier == item.insightIdentifier }) {
+            if (!merged.contains(where: { $0.identifier == item.identifier })) {
                 merged.append(item)
             }
         }
         
-        return merged.sorted(by: { ($0.date?.timeIntervalSince1970 ?? 0) < ($1.date?.timeIntervalSince1970 ?? 0) })
+        return merged
     }
     
     override open func loadFromBridge(completion: ((Bool) -> Void)?) {
@@ -120,21 +123,13 @@ open class InsightsUserDefaultsSingletonReport: UserDefaultsSingletonReport {
                 completion?(false)
                 return
             }
-            
-            guard report != nil else {
-                debugPrint("Insights data nil, assume first time user")
-                completion?(true)
-                return
-            }
-            
-            guard let bridgeJsonData = (report?.clientData as? String)?.data(using: .utf8) else {
-                print("Error parsing clientData for reminders report")
-                completion?(false)
-                return
-            }
 
             do {
-                let bridgeItems = try HistoryDataManager.shared.jsonDecoder.decode([InsightItemViewed].self, from: bridgeJsonData)
+                var bridgeItems = [LinkerStudy]()
+                // If this is the first time loading the report, it may be null or have client data missing
+                if let bridgeJsonData = (report?.clientData as? String)?.data(using: .utf8) {
+                    bridgeItems = try HistoryDataManager.shared.jsonDecoder.decode([LinkerStudy].self, from: bridgeJsonData)
+                }
                 let merged = self.mergeAndSortItems(cached: self.current ?? [], newItems: bridgeItems)
                 self.setCurrent(merged)
                 
@@ -163,7 +158,7 @@ open class InsightsUserDefaultsSingletonReport: UserDefaultsSingletonReport {
     }
 }
 
-public struct InsightItemViewed: Codable {
-    var insightIdentifier: String?
-    var date: Date?
+public struct LinkerStudy: Codable {
+    var identifier: String?
+    var startDate: Date?
 }

--- a/Psorcast/Psorcast/MasterScheduleManager.swift
+++ b/Psorcast/Psorcast/MasterScheduleManager.swift
@@ -63,6 +63,9 @@ open class MasterScheduleManager : SBAScheduleManager {
 
     private let kMetadataFilename                 = "metadata.json"
     
+    private static let studyStateFilename = "studyStates"
+    public static let fullStudyStateFilename = "\(studyStateFilename).json"
+    
     open var insightStepIdentifiers: [InsightResultIdentifier] {
         return [.insightViewedIdentifier, .insightViewedDate, .insightUsefulAnswer]
     }
@@ -108,20 +111,20 @@ open class MasterScheduleManager : SBAScheduleManager {
     }
     
     public func isComplete(schedule: SBBScheduledActivity) -> Bool {
-        guard let treatmentDate = HistoryDataManager.shared.currentTreatmentRange?.startDate else {
+        guard let studyDate = HistoryDataManager.shared.baseStudyStartDate else {
             return false
         }
-        let treatmentWeek = self.treatmentWeek()
-        let range = self.completionRange(treatmentDate: treatmentDate, treatmentWeek: treatmentWeek)
+        let studyWeek = self.baseStudyWeek()
+        let range = self.completionRange(date: studyDate, week: studyWeek)
         if let finishedOn = schedule.finishedOn {
             return range.contains(finishedOn)
         }
         return false
     }
     
-    func completionRange(treatmentDate: Date, treatmentWeek: Int) -> ClosedRange<Date> {
+    func completionRange(date: Date, week: Int) -> ClosedRange<Date> {
         // All schedules are treated as weekly finished on ranges
-        let rangeStart = treatmentDate.startOfDay().addingNumberOfDays(7 * (treatmentWeek - 1))
+        let rangeStart = date.startOfDay().addingNumberOfDays(7 * (week - 1))
         let rangeEnd = rangeStart.addingNumberOfDays(7)
         return rangeStart...rangeEnd
     }
@@ -159,7 +162,7 @@ open class MasterScheduleManager : SBAScheduleManager {
     
     /// The filter list is dynamic based on business requirements surrounding symptoms and diagnosis
     open var filterList: [RSDIdentifier] {
-        let treatmentWeek = self.treatmentWeek()
+        let studyWeek = self.baseStudyWeek()
         var includeList = [RSDIdentifier]()
         for rsdIdentifier in MasterScheduleManager.filterAll {
             let timingInfo = self.scheduleFrequency(for: rsdIdentifier)
@@ -168,8 +171,8 @@ open class MasterScheduleManager : SBAScheduleManager {
                 includeList.append(rsdIdentifier)
             } else if timingInfo.freq == .monthly {
                 // Only monthly activities that fall on the correct week are included
-                if treatmentWeek >= timingInfo.startWeek &&
-                    ((treatmentWeek - timingInfo.startWeek) % 4) == 0 {
+                if studyWeek >= timingInfo.startWeek &&
+                    ((studyWeek - timingInfo.startWeek) % 4) == 0 {
                     includeList.append(rsdIdentifier)
                 }
             } else {
@@ -288,6 +291,8 @@ open class MasterScheduleManager : SBAScheduleManager {
     /// Call from the view controller that is used to display the task when the task is ready to save.
     override open func taskController(_ taskController: RSDTaskController, readyToSave taskViewModel: RSDTaskViewModel) {
         
+        let taskId = taskController.task.identifier
+        
         // It is a requirement for our app to always upload the participantID with an upload
         if let participantID = UserDefaults.standard.string(forKey: MasterScheduleManager.resultIdParticipantID) {
             taskController.taskViewModel.taskResult.stepHistory.append(RSDAnswerResultObject(identifier: MasterScheduleManager.resultIdParticipantID, answerType: .string, value: participantID))
@@ -295,7 +300,7 @@ open class MasterScheduleManager : SBAScheduleManager {
         
         // Unless it is the treatment task itself, where this would be redundant,
         // add the treatment and study progress answer add-ons to every task upload
-        if RSDIdentifier.treatmentTask.rawValue != taskViewModel.task?.identifier {
+        if RSDIdentifier.treatmentTask.rawValue != taskId {
             createTreatmentAnswerAddOns().forEach { (addOnResult) in
                 taskController.taskViewModel.taskResult.stepHistory.append(addOnResult)
             }
@@ -304,8 +309,8 @@ open class MasterScheduleManager : SBAScheduleManager {
         // Add metadata around the progress in study information to every task upload
         if let studyStateResult = createStudyProgressAnswerAddOns(taskViewModel: taskViewModel) {
             taskController.taskViewModel.taskResult.stepHistory.append(studyStateResult)
-        }
-    
+        }    
+        
         let taskResult = taskController.taskViewModel.taskResult
         self.historyData.uploadReports(from: taskResult)
         
@@ -344,9 +349,22 @@ open class MasterScheduleManager : SBAScheduleManager {
         return addOns
     }
     
+    public func createStudyProgressData() -> Data? {
+        guard let current = HistoryDataManager.shared.studyDateData?.current else {
+            print("No study progress history to save")
+            return nil
+        }
+        do {
+            return try HistoryDataManager.shared.jsonEncoder.encode(current)
+        } catch {
+            print("Error encoding study progress info to JSON \(error.localizedDescription)")
+        }
+        return nil
+    }
+    
     /// For ease of data analysis, we should always upload study progress information
     public func createStudyProgressAnswerAddOns(taskViewModel: RSDTaskViewModel)-> RSDFileResultObject? {
-        guard let current = HistoryDataManager.shared.studyDateData?.current else {
+        guard let data = self.createStudyProgressData() else {
             print("No study progress history to save")
             return nil
         }
@@ -355,12 +373,11 @@ open class MasterScheduleManager : SBAScheduleManager {
                 print("No output dir to save to")
                 return nil
             }
-            let jsonStr = try HistoryDataManager.shared.jsonEncoder.encode(current)
             
             // Write json string to file
-            let identifier = "studyStates"
+            let identifier = MasterScheduleManager.studyStateFilename
             let url = try RSDFileResultUtility.createFileURL(identifier: identifier, ext: "json", outputDirectory: outputDir, shouldDeletePrevious: true)
-            try jsonStr.write(to: url, options: .atomic)
+            try data.write(to: url, options: .atomic)
             
             // Build and return file result object
             var fileResult = RSDFileResultObject(identifier: identifier)
@@ -384,6 +401,11 @@ open class MasterScheduleManager : SBAScheduleManager {
     public func treatmentWeek() -> Int {
         guard let currentTreatmentStart = self.treatmentDate() else { return 1 }
         return (Calendar.current.dateComponents([.weekOfYear], from: currentTreatmentStart.startOfDay(), to: nowDate()).weekOfYear ?? 0) + 1
+    }
+    
+    open func baseStudyWeek() -> Int {
+        guard let studyStart = HistoryDataManager.shared.baseStudyStartDate else { return 1 }
+        return (Calendar.current.dateComponents([.weekOfYear], from: studyStart.startOfDay(), to: nowDate()).weekOfYear ?? 0) + 1
     }
     
     open var selectedTreatmentItems: [TreatmentItem]? {

--- a/Psorcast/Psorcast/PassiveDataManager.swift
+++ b/Psorcast/Psorcast/PassiveDataManager.swift
@@ -272,7 +272,7 @@ open class PassiveDataManager {
     private func createArchive(identifier: String) -> SBBDataArchive {
         // Archive to add data to as our queries succeed
         let archive = SBBDataArchive(reference: identifier, jsonValidationMapping: nil)
-                
+        
         // Add the current data groups and the user's arc id
         var metadata = [String: Any]()
         if let dataGroups = SBAParticipantManager.shared.studyParticipant?.dataGroups {
@@ -301,6 +301,13 @@ open class PassiveDataManager {
         let treatmentAddOns = MasterScheduleManager.shared.createTreatmentAnswerAddOns()
         if (treatmentAddOns.count > 0) {
             treatmentAddOns.forEach({ answersDict[$0.identifier] = $0.value })
+        }
+        
+        // Add on study progress info
+        if let data = MasterScheduleManager.shared.createStudyProgressData() {
+            archive.insertData(intoArchive: data,
+                               filename: MasterScheduleManager.fullStudyStateFilename,
+                               createdOn: Date())
         }
         
         archive.insertAnswersDictionary(answersDict)

--- a/Psorcast/Psorcast/SignInTaskViewController.swift
+++ b/Psorcast/Psorcast/SignInTaskViewController.swift
@@ -97,7 +97,7 @@ public class SignInTaskViewController: RSDTaskViewController, SignInDelegate {
         signUp.phone!.number = phoneNumber
         signUp.phone!.regionCode = regionCode
         
-        signUp.dataGroups = [LinkerStudiesUserDefaultsSingletonReport.LINKER_STUDY_BETA_2021]
+        signUp.dataGroups = [HistoryDataManager.LINKER_STUDY_BETA_2021]
         signUp.sharingScope = "all_qualified_researchers"
         
         BridgeSDK.authManager.signUpStudyParticipant(signUp, completion: { (task, result, error) in

--- a/Psorcast/Psorcast/SignInTaskViewController.swift
+++ b/Psorcast/Psorcast/SignInTaskViewController.swift
@@ -97,7 +97,7 @@ public class SignInTaskViewController: RSDTaskViewController, SignInDelegate {
         signUp.phone!.number = phoneNumber
         signUp.phone!.regionCode = regionCode
         
-        signUp.dataGroups = ["BETA2021"]
+        signUp.dataGroups = [LinkerStudiesUserDefaultsSingletonReport.LINKER_STUDY_BETA_2021]
         signUp.sharingScope = "all_qualified_researchers"
         
         BridgeSDK.authManager.signUpStudyParticipant(signUp, completion: { (task, result, error) in

--- a/Psorcast/Psorcast/StudyTaskFactory.swift
+++ b/Psorcast/Psorcast/StudyTaskFactory.swift
@@ -144,19 +144,6 @@ extension SBAProfileDataSourceType {
 
 open class StudyBridgeConfiguration: SBABridgeConfiguration {
     
-    override open func schemaInfo(for activityIdentifier: String) -> RSDSchemaInfo? {
-        // TODO: mdephillips 5/14/20 remove after deep dive surveys are real and not fake
-        if activityIdentifier == "DeepDiveTest1" ||
-            activityIdentifier == "DeepDiveTest2" ||
-            activityIdentifier == "DeepDiveTest3" ||
-            activityIdentifier == "PastTreatments" ||
-            activityIdentifier == "Demographics" ||
-            activityIdentifier == "SymptomHistory" {
-            return RSDSchemaInfoObject(identifier: activityIdentifier, revision: 1)
-        }
-        return super.schemaInfo(for: activityIdentifier)
-    }
-    
     override open func addConfigElementMapping(for key: String, with json: SBBJSONValue) throws {
         
         do {

--- a/Psorcast/PsorcastTests/MasterScheduleManagerTests.swift
+++ b/Psorcast/PsorcastTests/MasterScheduleManagerTests.swift
@@ -84,13 +84,13 @@ class MasterScheduleManagerTests: XCTestCase {
     func testCompletionRange() {
         mockManager.mockNow = date(28, 5, 0, 0)
         mockManager.mockTreatmentDate = date(25, 5, 0, 0)
-        var range = mockManager.completionRange(treatmentDate: mockManager.mockTreatmentDate, treatmentWeek: mockManager.treatmentWeek())
+        var range = mockManager.completionRange(date: mockManager.mockTreatmentDate, week: mockManager.treatmentWeek())
         XCTAssertEqual(range.lowerBound, date(25, 0, 0, 0))
         XCTAssertEqual(range.upperBound, date(32, 0, 0, 0))
         
         mockManager.mockNow = date(34, 5, 0, 0)
         mockManager.mockTreatmentDate = date(25, 5, 0, 0)
-        range = mockManager.completionRange(treatmentDate: mockManager.mockTreatmentDate, treatmentWeek: mockManager.treatmentWeek())
+        range = mockManager.completionRange(date: mockManager.mockTreatmentDate, week: mockManager.treatmentWeek())
         XCTAssertEqual(range.lowerBound, date(32, 0, 0, 0))
         XCTAssertEqual(range.upperBound, date(39, 0, 0, 0))
     }
@@ -289,6 +289,10 @@ open class MockMasterScheduleManager: MasterScheduleManager {
     var mockTreatmentDate = Date()
     override open func treatmentDate() -> Date? {
         return mockTreatmentDate
+    }
+    
+    override open func baseStudyWeek() -> Int {
+        return super.treatmentWeek()
     }
 
     var mockSymptoms: String?

--- a/Psorcast/PsorcastTests/MeasureTabViewControllerTests.swift
+++ b/Psorcast/PsorcastTests/MeasureTabViewControllerTests.swift
@@ -139,7 +139,7 @@ class MeasureTabViewControllerTests: XCTestCase {
 
 open class MockMeasureTabViewController: MeasureTabViewController {
     var mockWeek = 1
-    override open func treatmentWeek() -> Int {
+    override open func studyWeek() -> Int {
         return mockWeek
     }
 }

--- a/Psorcast/PsorcastValidation/PsorcastIdentifiers.swift
+++ b/Psorcast/PsorcastValidation/PsorcastIdentifiers.swift
@@ -56,6 +56,9 @@ public extension RSDIdentifier {
     
     // Insight tasks
     static let insightsTask: RSDIdentifier = "Insights"
+    
+    // Study Dates Holding Task
+    static let studyDates: RSDIdentifier = "StudyDates"
 }
 
 extension MCTTaskInfo : SBAActivityInfo {


### PR DESCRIPTION
App changes:
1) Added study date tracking for linker studies. After consent, I set the start date for both "PsorcastUS" and "BETA2021" studies.
2) Switched measure tab over to using the study start date instead of the treatment start date.
3) Fixed bug where deep dive surveys were locked to schema version 1

Bridge changes:
Bumped all schemas up a version and added "studyStates.json" to all uploads. 
This file looks like this:

```
[
  {
    "startDate": "2021-10-29T19:15:24Z",
    "identifier": "PsorcastUS"
  },
  {
    "startDate": "2021-10-29T19:15:24Z",
    "identifier": "BETA2021"
  }
]
```
