### PR TITLE
Psr 493

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		043781B1270EB34F001F374F /* ConsentForm_files in Resources */ = {isa = PBXBuildFile; fileRef = 043781B0270EB34F001F374F /* ConsentForm_files */; };
 		043781B7270EC448001F374F /* ConsentFormOnboarding.html in Resources */ = {isa = PBXBuildFile; fileRef = 043781B4270EC374001F374F /* ConsentFormOnboarding.html */; };
 		043781C2270ECCB7001F374F /* Licenses.html in Resources */ = {isa = PBXBuildFile; fileRef = 043781BD270ECCB7001F374F /* Licenses.html */; };
+		0456535F2731F22A00BEA3CA /* PsorcastParticipantCustomAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 0456535E2731F22A00BEA3CA /* PsorcastParticipantCustomAttributes.m */; };
 		047C2CCF25F16628006AA52B /* PopTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047C2CCC25F16628006AA52B /* PopTip.swift */; };
 		047C2CD025F16628006AA52B /* PopTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047C2CCC25F16628006AA52B /* PopTip.swift */; };
 		047C2CD125F16628006AA52B /* PopTip+Draw.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047C2CCD25F16628006AA52B /* PopTip+Draw.swift */; };
@@ -430,6 +431,7 @@
 		043781B0270EB34F001F374F /* ConsentForm_files */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ConsentForm_files; sourceTree = "<group>"; };
 		043781B4270EC374001F374F /* ConsentFormOnboarding.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = ConsentFormOnboarding.html; sourceTree = "<group>"; };
 		043781BD270ECCB7001F374F /* Licenses.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = Licenses.html; sourceTree = "<group>"; };
+		0456535E2731F22A00BEA3CA /* PsorcastParticipantCustomAttributes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PsorcastParticipantCustomAttributes.m; sourceTree = "<group>"; };
 		047C2CCC25F16628006AA52B /* PopTip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopTip.swift; sourceTree = "<group>"; };
 		047C2CCD25F16628006AA52B /* PopTip+Draw.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PopTip+Draw.swift"; sourceTree = "<group>"; };
 		047C2CCE25F16628006AA52B /* PopTip+Transitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PopTip+Transitions.swift"; sourceTree = "<group>"; };
@@ -1060,6 +1062,7 @@
 			children = (
 				CBDCDCC123F3855300E5CEB8 /* BuildDateUtil.m */,
 				CBDCDCC323F3857600E5CEB8 /* Psorcast-Bridging-Header.h */,
+				0456535E2731F22A00BEA3CA /* PsorcastParticipantCustomAttributes.m */,
 			);
 			name = ObjC;
 			sourceTree = "<group>";
@@ -1711,6 +1714,7 @@
 				CBDCDCA723F3849E00E5CEB8 /* PsoriasisAreaPhotoImageView.swift in Sources */,
 				CBDCDCAC23F3849E00E5CEB8 /* PsoriasisDrawStepObject.swift in Sources */,
 				CBB0F43A2643D1B0007442F3 /* PassiveDataManager.swift in Sources */,
+				0456535F2731F22A00BEA3CA /* PsorcastParticipantCustomAttributes.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Psorcast/Psorcast/BuildDateUtil.m
+++ b/Psorcast/Psorcast/BuildDateUtil.m
@@ -32,6 +32,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <BridgeSDK/BridgeSDK.h>
 
 /**
  The __DATE__ macro will return a string representation
@@ -40,3 +41,16 @@
 NSString *compileDate() {
     return [NSString stringWithUTF8String:__DATE__];
 }
+
+@interface SBBStudyParticipantCustomAttributes (customFields)
+
+@property (nonatomic, strong) NSString *compensateEmail;
+
+
+@end
+
+@implementation SBBStudyParticipantCustomAttributes (customFields)
+
+@dynamic compensateEmail;
+
+@end

--- a/Psorcast/Psorcast/ProfileTabViewController.swift
+++ b/Psorcast/Psorcast/ProfileTabViewController.swift
@@ -336,6 +336,9 @@ class ProfileTabViewController: UIViewController, UITableViewDelegate, UITableVi
                 navVC.modalPresentationStyle = .pageSheet
                 self.present(navVC, animated: true, completion: nil)
             } else if profileItem.profileItemKey == RSDIdentifier.emailCompensationTask.rawValue {
+                // Clear the local value of the email so when they come back, it
+                // won't temporarily show the old value until we've updated what it should show
+                self.storedCompensationEmail = ""
                 self.showJsonTaskViewControler(jsonName: ProfileTabViewController.changeEmailTaskId)
             } else if let vc = MasterScheduleManager.shared.instantiateSingleQuestionTreatmentTaskController(for: profileItem.profileItemKey) {
                 vc.delegate = self

--- a/Psorcast/Psorcast/ProfileTabViewController.swift
+++ b/Psorcast/Psorcast/ProfileTabViewController.swift
@@ -130,8 +130,6 @@ class ProfileTabViewController: UIViewController, UITableViewDelegate, UITableVi
         BridgeSDK.participantManager.getParticipantRecord(completion: { record, error in
             DispatchQueue.main.async {
                 guard let participant = record as? SBBStudyParticipant, error == nil else { return }
-                let attributes = participant.attributes
-                let dic = attributes?.dictionaryRepresentation()
                 if let compensationEmail = participant.attributes?.dictionaryRepresentation()[RequestEmailViewController.COMPENSATE_ATTRIBUTE] as? String {
                     // We now have the email address, so save it and have the table view reload
                     self.storedCompensationEmail = compensationEmail

--- a/Psorcast/Psorcast/Psorcast-Bridging-Header.h
+++ b/Psorcast/Psorcast/Psorcast-Bridging-Header.h
@@ -41,16 +41,3 @@
  Example format: May 18 2019
  */
 NSString* compileDate();
-
-@interface SBBStudyParticipantCustomAttributes (customFields)
-
-@property (nonatomic, strong) NSString *compensateEmail;
-
-
-@end
-
-@implementation SBBStudyParticipantCustomAttributes (customFields)
-
-@dynamic compensateEmail;
-
-@end

--- a/Psorcast/Psorcast/PsorcastParticipantCustomAttributes.m
+++ b/Psorcast/Psorcast/PsorcastParticipantCustomAttributes.m
@@ -1,8 +1,8 @@
 ///
-//  BuildDateUtil.m
-//  PsorcastValidation
+//  PsorcastParticipantCustomAttributes.m
+//  Psorcast
 //
-//  Copyright © 2019 Sage Bionetworks. All rights reserved.
+//  Copyright © 2021 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -31,12 +31,19 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#import <Foundation/Foundation.h>
 
-/**
- The __DATE__ macro will return a string representation
- of the date the app was built.
- */
-NSString *compileDate() {
-    return [NSString stringWithUTF8String:__DATE__];
-}
+#import <Foundation/Foundation.h>
+#import <BridgeSDK/BridgeSDK.h>
+
+@interface SBBStudyParticipantCustomAttributes (customFields)
+
+@property (nonatomic, strong) NSString *compensateEmail;
+
+
+@end
+
+@implementation SBBStudyParticipantCustomAttributes (customFields)
+
+@dynamic compensateEmail;
+
+@end

--- a/Psorcast/Psorcast/RequestEmailViewController.swift
+++ b/Psorcast/Psorcast/RequestEmailViewController.swift
@@ -106,11 +106,6 @@ class RequestEmailViewController: RSDTableStepViewController {
                         self.present(alert, animated: true)
                         return
                     }
-                    // We've successfully uploaded, however there's currently an issue with later pulling attributes
-                    // down from bridge. As an interim stopgap, go ahead and store the email locally so we can
-                    // populate the appropriate field in the profile
-                    // TODO: ESIEG 11/19/21 Remove this stopgap
-                    UserDefaults.standard.set(emailText, forKey: RequestEmailViewController.COMPENSATE_ATTRIBUTE)
                     super.goForward()
                 }
             }


### PR DESCRIPTION
This removes the user defaults stopgap for retrieving attributes, and now correctly populates from bridge attributes.
It also cleans up the PSR 510 solution where bogus detailText values were showing up for some profile items.