### PR TITLE
PSR-511

### DIFF
--- a/Psorcast/Psorcast/HistoryDataManager.swift
+++ b/Psorcast/Psorcast/HistoryDataManager.swift
@@ -315,12 +315,6 @@ open class HistoryDataManager {
             let report = self.createHistoryReport(from: taskResult)
             self.addHistoryItemToCoredData(reports: [report])
             self.saveReport(report)
-            
-            // After the new report is saved, we should re-create its treatment video
-            if let treatmentRange = self.currentTreatmentRange {
-                // We should re-export the most recent treatment task video if we have a new frame
-                ImageDataManager.shared.recreateCurrentTreatmentVideo(for: taskResult.identifier, with: treatmentRange)
-            }
         }
         
         // Update the local storage of the singleton data

--- a/Psorcast/Psorcast/ImageDataManager.swift
+++ b/Psorcast/Psorcast/ImageDataManager.swift
@@ -122,6 +122,13 @@ open class ImageDataManager {
         // Copy new video frames into the documents directory
         // Copy the result file url into a the local cache so it persists upload complete
         if let newImageUrl = FileManager.default.copyFile(at: summaryImageUrl, to: storageDir, filename: imageFileName) {
+            
+            // Re-create current treatment video if we found a new image
+            if let treatmentRange = self.historyData.currentTreatmentRange {
+                // We should re-export the most recent treatment task video if we have a new frame
+                self.recreateCurrentTreatmentVideo(for: taskIdentifier, with: treatmentRange)
+            }
+            
             // Let the app know about the new image so it can update the UI
             self.postImageFrameAddedNotification(url: newImageUrl)
             
@@ -197,6 +204,7 @@ open class ImageDataManager {
         // Check if it is in the process of being created
         if self.videoCreatorTasks.filter({ $0.settings.videoFilename == videoFilename }).count > 0 {
             debugPrint("Video is already being created, do not start it again")
+         
             return
         }
         


### PR DESCRIPTION
This code used to be in the ImageDataManager but move to another spot in the code in late 2020. I'm not sure why it was moved, but it is critical that the videos being rendered have the image frame ready, which the new spot guarantees.  Otherwise, the export may fail and have to re-try, which I believe is what you are seeing.  This creates a brief time where the UI thinks the video is valid and allows the button to be clickable.