### PR TITLE
PSR-517

### DIFF
--- a/Psorcast/Psorcast.xcodeproj/project.pbxproj
+++ b/Psorcast/Psorcast.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		CB778672238D0E440009ECF9 /* DigitalJarOpenCompletionStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB778671238D0E440009ECF9 /* DigitalJarOpenCompletionStepViewController.swift */; };
 		CB778674238D18F30009ECF9 /* DigitalJarOpenCompletionStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB778673238D18F30009ECF9 /* DigitalJarOpenCompletionStepViewController.xib */; };
 		CB7CF2482400CFAA003E02A5 /* WelcomeVideo.mov in Resources */ = {isa = PBXBuildFile; fileRef = CB7CF2472400CFAA003E02A5 /* WelcomeVideo.mov */; };
+		CB7E9438274DC6FF0058780E /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBB0F4322643D0C7007442F3 /* HealthKit.framework */; };
 		CB81C92E242D3AB100A84886 /* MeasureTabViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB81C92D242D3AB100A84886 /* MeasureTabViewControllerTests.swift */; };
 		CB85FB52235F505300FDC59B /* PsorcastTaskResultProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85FB51235F505300FDC59B /* PsorcastTaskResultProcessor.swift */; };
 		CB85FB56235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB85FB55235F5C5500FDC59B /* SelectedIdentifiersResultObject.swift */; };
@@ -702,6 +703,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB7E9438274DC6FF0058780E /* HealthKit.framework in Frameworks */,
 				CBDCDCC523F385AF00E5CEB8 /* BridgeApp.framework in Frameworks */,
 				CBDCDCD423F385DA00E5CEB8 /* Research.framework in Frameworks */,
 				CBDCDCDA23F385EC00E5CEB8 /* ResearchUI.framework in Frameworks */,

--- a/Psorcast/Psorcast/Info.plist
+++ b/Psorcast/Psorcast/Info.plist
@@ -29,11 +29,13 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Psorcast would like to get your location of your phone to get the weather and air quality, then we’ll delete the GPS data from the phone’s temporary storage.</string>
 	<key>NSMotionUsageDescription</key>
-	<string>Psorcast would like to access your phone's motion sensors to help gather data during activities.</string>
+	<string>Psorcast would like to access your phone&apos;s motion sensors to help gather data during activities.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Psorcast would like to export your image and video data to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Psorcast can export your image and video data to your photo library.</string>
+	<key>NSHealthClinicalHealthRecordsShareUsageDescription</key>
+	<string>Psorcast would like to access de-identified clinical records to compare diagnoses and medications for our research study.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>lato_black.ttf</string>

--- a/Psorcast/Psorcast/Psorcast.entitlements
+++ b/Psorcast/Psorcast/Psorcast.entitlements
@@ -5,7 +5,9 @@
 	<key>com.apple.developer.healthkit</key>
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>
-	<array/>
+	<array>
+		<string>health-records</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)org.sagebionetworks.Psorcast</string>

--- a/Psorcast/PsorcastValidation/Info.plist
+++ b/Psorcast/PsorcastValidation/Info.plist
@@ -21,9 +21,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>This app would like to access your camera to capture images of your Psoriasis.</string>
+	<string>Psorcast would like to access your camera to capture images of your Psoriasis.</string>
 	<key>NSMotionUsageDescription</key>
-	<string>Psorcast would like to access your phone's motion sensors to help gather data during activities.</string>
+	<string>Psorcast would like to access your phone&apos;s motion sensors to help gather data during activities.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>lato_black.ttf</string>


### PR DESCRIPTION
Added new health kit data endpoints.  These all need tested by you @DanWebster I have tested some of them, but am having trouble figuring out how to test them all.  See the data upload below.

This involved adding the clinical health type entitlement, as well as a plist string describing the reason the app wants this permission.  

Clinical endpoints are queried the same and the other HealthKit samples, but the JSON returned is unique.  The health care institution will always upload JSON, but it is free-form, so there is no way for us to parse, so I have to upload a escaped JSON String as a field instead of a JSON object itself. 

See this example of clinical uploads to bridge
[HealthKitNewFields.zip](https://github.com/Sage-Bionetworks/Psorcast-iOS/files/7610973/HealthKitNewFields.zip)


I am also having trouble finding where I can enter in fitzpatrick skin type, but the json should come through in  FitzpatrickSkinType.json with the format:
{
   "skinType": [an integer with range 1-5]
}
