### PR TITLE
FileApiUpload

### DIFF
--- a/Psorcast/Psorcast/HistoryDataManager.swift
+++ b/Psorcast/Psorcast/HistoryDataManager.swift
@@ -444,7 +444,7 @@ open class HistoryDataManager {
 
     func deleteAllHistoryEntities() {
         guard let context = self.currentContext else { return }
-        context.perform {
+        context.performAndWait {
             let fetchRequest: NSFetchRequest<HistoryItem> = HistoryItem.fetchRequest()
             fetchRequest.returnsObjectsAsFaults = false
             do {
@@ -453,6 +453,7 @@ open class HistoryDataManager {
                     context.delete(object)
                 }
                 try context.save()
+                print("Successfully deleted all past history items")
             } catch let error {
                 print("Detele all history items encountered error :", error)
             }

--- a/Psorcast/Psorcast/ImageDataManager.swift
+++ b/Psorcast/Psorcast/ImageDataManager.swift
@@ -132,6 +132,11 @@ open class ImageDataManager {
             // Let the app know about the new image so it can update the UI
             self.postImageFrameAddedNotification(url: newImageUrl)
             
+            // Delay a second to give other events and network calls time to run first
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: {
+                ParticipantFileUploadManager.shared.upload(fileId: imageFileName, fileUrl: newImageUrl, contentType: PSRImageHelper.contentTypeJpeg)
+            })
+            
             return imageFileName
         } else { // Not successful
             debugPrint("Error copying file from \(summaryImageUrl.absoluteURL)" +


### PR DESCRIPTION
Upload all review tab images to the bridge file api.

I also fixed a critical bug that we weren’t aware of.  Reloading a user’s history when they sign in with an existing account was broken!  The CoreData request was not waiting to complete, so the order of operations was mismatch.  When a user would complete sign in, they would save their history items first, and then immediately delete them.