### PR TITLE
PSR-542

### DIFF
--- a/Psorcast/PsorcastValidation/TaskFactory.swift
+++ b/Psorcast/PsorcastValidation/TaskFactory.swift
@@ -96,7 +96,7 @@ open class TaskFactory: SBAFactory {
 open class NoPsoriasisStepObject: RSDUIStepObject, RSDNavigationSkipRule {
     
     public func shouldSkipStep(with result: RSDTaskResult?, isPeeking: Bool) -> Bool {
-        if let collectionResult = (result?.findResult(with: RSDStepType.selectionCollection.rawValue) as? RSDCollectionResultObject) {
+        if let collectionResult = (result?.stepHistory.last(where: {$0.identifier.starts(with: RSDStepType.selectionCollection.rawValue)})) as? RSDCollectionResultObject {
             let answerResult = collectionResult.inputResults.first as? RSDAnswerResultObject
             let answers = answerResult?.value as? [String]
             return (answerResult != nil && (answers?.count ?? 0) > 0)


### PR DESCRIPTION
Resolve issue when tasks have multiple selectionCollection results used for conditional navigation.  This applied to the flow of the SymptomHistory deep dive task.